### PR TITLE
Add reporting functionality to Elk

### DIFF
--- a/components/account/AccountMoreButton.vue
+++ b/components/account/AccountMoreButton.vue
@@ -153,6 +153,13 @@ async function removeUserNote() {
               @click="toggleBlockDomain(relationship!, account)"
             />
           </template>
+
+          <CommonDropdownItem
+            :text="$t('menu.report_account', [`@${account.acct}`])"
+            icon="i-ri:flag-2-line"
+            :command="command"
+            @click="openReportDialog(account)"
+          />
         </template>
 
         <template v-else>

--- a/components/modal/ModalContainer.vue
+++ b/components/modal/ModalContainer.vue
@@ -11,6 +11,7 @@ import {
   isMediaPreviewOpen,
   isPreviewHelpOpen,
   isPublishDialogOpen,
+  isReportDialogOpen,
   isSigninDialogOpen,
 } from '~/composables/dialog'
 
@@ -101,6 +102,9 @@ function handleFavouritedBoostedByClose() {
     </ModalDialog>
     <ModalDialog v-model="isKeyboardShortcutsDialogOpen" max-w-full sm:max-w-140 md:max-w-170 lg:max-w-220 md:min-w-160>
       <MagickeysKeyboardShortcuts @close="closeKeyboardShortcuts()" />
+    </ModalDialog>
+    <ModalDialog v-model="isReportDialogOpen" keep-alive max-w-125>
+      <ReportModal :account="reportAccount" :status="reportStatus" @close="closeReportDialog()" />
     </ModalDialog>
   </template>
 </template>

--- a/components/report/ReportModal.vue
+++ b/components/report/ReportModal.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import type { mastodon } from 'masto'
+import { toggleBlockAccount, toggleFollowAccount, toggleMuteAccount, useRelationship } from '~~/composables/masto/relationship'
+
+const { account, status } = defineProps<{
+  account: mastodon.v1.Account
+  status: mastodon.v1.Status
+}>()
+
+const emit = defineEmits<{
+  (event: 'close'): void
+}>()
+
+const { client } = useMasto()
+
+const step = ref('choose')
+const serverRules = ref((await client.value.v2.instance.fetch()).rules || [])
+const reportReason = ref('')
+const selectedRuleIds = ref([])
+const additionalComments = ref('')
+const forwardReport = ref(false)
+
+const dismissButton = ref<HTMLDivElement>()
+
+async function submitReport() {
+  await client.value.v1.reports.create({
+    accountId: account.id,
+    statusIds: status?.id ? [status.id] : null,
+    comment: additionalComments.value,
+    forward: forwardReport.value,
+    category: reportReason.value === 'spam' ? 'spam' : reportReason.value === 'violation' ? 'violation' : 'other',
+    ruleIds: reportReason.value === 'violation' ? selectedRuleIds.value : null,
+  })
+  step.value = 'thanks'
+  // TODO: extract this scroll/reset logic into ModalDialog element
+  dismissButton.value?.scrollIntoView() // scroll to top
+}
+
+function unfollow() {
+  emit('close')
+  toggleFollowAccount(useRelationship(account).value!, account)
+}
+
+function mute() {
+  emit('close')
+  toggleMuteAccount(useRelationship(account).value!, account)
+}
+
+function block() {
+  emit('close')
+  toggleBlockAccount(useRelationship(account).value!, account)
+}
+</script>
+
+<template>
+  <div my-8 px-3 sm:px-8 flex="~ col gap-4" relative>
+    <h2 mxa text-xl>
+      {{ reportReason === 'dontlike' ? "Limiting" : "Reporting" }} <b text-primary>@{{ account.acct }}</b>
+    </h2>
+    <button ref="dismissButton" btn-action-icon absolute top--8 right-0 m1 aria-label="Close" @click="emit('close')">
+      <div i-ri:close-line />
+    </button>
+
+    <template v-if="step === 'choose'">
+      <h1 mxa text-4xl mb4>
+        Tell us what's wrong with this {{ status ? "post" : "account" }}
+      </h1>
+      <p text-xl>
+        Choose the best match:
+      </p>
+
+      <div>
+        <input id="dontlike" v-model="reportReason" type="radio" value="dontlike">
+        <label pl-2 for="dontlike" font-bold>I don't like it</label>
+        <p pl-6>
+          It is not something you want to see
+        </p>
+      </div>
+
+      <div>
+        <input id="spam" v-model="reportReason" type="radio" value="spam">
+        <label pl-2 for="spam" font-bold>It's spam</label>
+        <p pl-6>
+          Malicious links, fake engagement, or repetitive replies
+        </p>
+      </div>
+
+      <div v-if="serverRules.length > 0">
+        <input id="violation" v-model="reportReason" type="radio" value="violation">
+        <label pl-2 for="violation" font-bold>It violates one or more of the server rules</label>
+        <p v-if="reportReason === 'violation'" pl-6 pt-2 text-primary font-bold>
+          Select all that apply:
+        </p>
+        <ul pl-6>
+          <li v-for="rule in serverRules" :key="rule.id" pt-2>
+            <input
+              :id="rule.id"
+              v-model="selectedRuleIds"
+              type="checkbox"
+              :value="rule.id"
+              :disabled="reportReason !== 'violation'"
+            >
+            <label pl-2 :for="rule.id">{{ rule.text }}</label>
+          </li>
+        </ul>
+      </div>
+
+      <div>
+        <input id="other" v-model="reportReason" type="radio" value="other">
+        <label pl-2 for="other" font-bold>It's something else</label>
+        <p pl-6>
+          The issue does not fit into other categories
+        </p>
+      </div>
+
+      <div v-if="reportReason && reportReason !== 'dontlike'">
+        <h3 mt-8 mb-4 font-bold>
+          Is there anything else you think we should know?
+        </h3>
+        <textarea v-model="additionalComments" w-full h-20 p-3 border placeholder="Additional Comments" />
+        <div v-if="getServerName(account) && getServerName(account) !== currentServer">
+          <h3 mt-8 mb-2 font-bold>
+            The user you're reporting is from another server
+          </h3>
+          <p pb-1>
+            Do you want to send an anonymized copy of this report to that server as well?
+          </p>
+          <input id="forward" v-model="forwardReport" type="checkbox" value="rule.id">
+          <label pl-2 for="forward"><b>Yes, forward this report to {{ getServerName(account) }}</b></label>
+        </div>
+      </div>
+
+      <button
+        btn-solid mxa mt-10
+        :disabled="!reportReason || (reportReason === 'violation' && selectedRuleIds.length < 1)"
+        tabindex="2"
+        @click="submitReport()"
+      >
+        {{ reportReason === 'dontlike' ? "Next" : "Submit Report" }}
+      </button>
+    </template>
+
+    <template v-else-if="step === 'thanks'">
+      <h1 mxa text-4xl mb4>
+        {{ reportReason === 'dontlike' ? "Don't want to see this?" : "Thanks for reporting, we'll look into this." }}
+      </h1>
+      <p text-xl>
+        {{ reportReason === 'dontlike' ? "Here are your options for controlling what you see:" : "While we review this, here are the actions you can take:" }}
+      </p>
+
+      <div v-if="useRelationship(account).value?.following">
+        <button btn-outline mxa mt-4 mb-2 tabindex="2" @click="unfollow()">
+          Unfollow <b>@{{ account.acct }}</b>
+        </button><br>
+        You will no longer see posts from this user in your home feed. You may still see posts from them elsewhere.
+      </div>
+      <div v-if="!useRelationship(account).value?.muting">
+        <button btn-outline mxa mt-4 mb-2 tabindex="3" @click="mute()">
+          Mute <b>@{{ account.acct }}</b>
+        </button><br>
+        You will no longer see any posts from this user. They can still follow you and see your posts. They will not know that they are muted.
+      </div>
+      <div v-if="!useRelationship(account).value?.blocking">
+        <button btn-outline mxa mt-4 mb-2 tabindex="4" @click="block()">
+          Block <b>@{{ account.acct }}</b>
+        </button><br>
+        You will no longer see any posts from this user. They will not be able to see your posts or follow you. They will be able to tell that they are blocked.
+      </div>
+      <button btn-solid mxa mt-10 tabindex="5" @click="emit('close')">
+        Done
+      </button>
+    </template>
+  </div>
+</template>

--- a/components/report/ReportModal.vue
+++ b/components/report/ReportModal.vue
@@ -12,6 +12,7 @@ const emit = defineEmits<{
 }>()
 
 const { client } = useMasto()
+const { t } = useI18n()
 
 const step = ref('selectCategory')
 const serverRules = ref((await client.value.v2.instance.fetch()).rules || [])
@@ -93,7 +94,9 @@ function resetModal() {
 <template>
   <div my-8 px-3 sm:px-8 flex="~ col gap-4" relative>
     <h2 mxa text-xl>
-      {{ reportReason === 'dontlike' ? "Limiting" : "Reporting" }} <b text-primary>@{{ account.acct }}</b>
+      <i18n-t :keypath="reportReason === 'dontlike' ? 'report.limiting' : 'report.reporting'">
+        <b text-primary>@{{ account.acct }}</b>
+      </i18n-t>
     </h2>
     <button ref="dismissButton" btn-action-icon absolute top--8 right-0 m1 aria-label="Close" @click="emit('close')">
       <div i-ri:close-line />
@@ -101,33 +104,33 @@ function resetModal() {
 
     <template v-if="step === 'selectCategory'">
       <h1 mxa text-4xl mb4>
-        Tell us what's wrong with this {{ status ? "post" : "account" }}
+        {{ status ? $t('report.whats_wrong_post') : $t('report.whats_wrong_account') }}
       </h1>
       <p text-xl>
-        Choose the best match:
+        {{ $t('report.select_one') }}
       </p>
 
       <div>
         <input id="dontlike" v-model="reportReason" type="radio" value="dontlike">
-        <label pl-2 for="dontlike" font-bold>I don't like it</label>
+        <label pl-2 for="dontlike" font-bold>{{ $t('report.dontlike') }}</label>
         <p pl-6>
-          It is not something you want to see
+          {{ $t('report.dontlike_desc') }}
         </p>
       </div>
 
       <div>
         <input id="spam" v-model="reportReason" type="radio" value="spam">
-        <label pl-2 for="spam" font-bold>It's spam</label>
+        <label pl-2 for="spam" font-bold>{{ $t('report.spam') }}</label>
         <p pl-6>
-          Malicious links, fake engagement, or repetitive replies
+          {{ $t('report.spam_desc') }}
         </p>
       </div>
 
       <div v-if="serverRules.length > 0">
         <input id="violation" v-model="reportReason" type="radio" value="violation">
-        <label pl-2 for="violation" font-bold>It violates one or more of the server rules</label>
+        <label pl-2 for="violation" font-bold>{{ $t('report.violation') }}</label>
         <p v-if="reportReason === 'violation'" pl-6 pt-2 text-primary font-bold>
-          Select all that apply:
+          {{ $t('report.select_many') }}
         </p>
         <ul pl-6>
           <li v-for="rule in serverRules" :key="rule.id" pt-2>
@@ -145,26 +148,26 @@ function resetModal() {
 
       <div>
         <input id="other" v-model="reportReason" type="radio" value="other">
-        <label pl-2 for="other" font-bold>It's something else</label>
+        <label pl-2 for="other" font-bold>{{ $t('report.other') }}</label>
         <p pl-6>
-          The issue does not fit into other categories
+          {{ $t('report.other_desc') }}
         </p>
       </div>
 
       <div v-if="reportReason && reportReason !== 'dontlike'">
         <h3 mt-8 mb-4 font-bold>
-          Is there anything else you think we should know?
+          {{ $t('report.anything_else') }}
         </h3>
-        <textarea v-model="additionalComments" w-full h-20 p-3 border placeholder="Additional Comments" />
+        <textarea v-model="additionalComments" w-full h-20 p-3 border :placeholder="$t('report.additional_comments')" />
         <div v-if="getServerName(account) && getServerName(account) !== currentServer">
           <h3 mt-8 mb-2 font-bold>
-            The user you're reporting is from another server
+            {{ $t('report.another_server') }}
           </h3>
           <p pb-1>
-            Do you want to send an anonymized copy of this report to that server as well?
+            {{ $t('report.forward_question') }}
           </p>
           <input id="forward" v-model="forwardReport" type="checkbox" value="rule.id">
-          <label pl-2 for="forward"><b>Yes, forward this report to {{ getServerName(account) }}</b></label>
+          <label pl-2 for="forward"><b>{{ $t('report.forward', [getServerName(account)]) }}</b></label>
         </div>
       </div>
 
@@ -173,16 +176,16 @@ function resetModal() {
         :disabled="!reportReason || (reportReason === 'violation' && selectedRuleIds.length < 1)"
         @click="categoryChosen()"
       >
-        Next
+        {{ $t('action.next') }}
       </button>
     </template>
 
     <template v-else-if="step === 'selectStatuses'">
       <h1 mxa text-4xl mb4>
-        Are there any {{ status ? "other" : "" }} posts that back up this report?
+        {{ status ? $t('report.select_posts_other') : $t('report.select_posts') }}
       </h1>
       <p text-primary font-bold>
-        Select all that apply:
+        {{ $t('report.select_many') }}
       </p>
       <table>
         <tr v-for="availableStatus in availableStatuses" :key="availableStatus.id">
@@ -205,38 +208,44 @@ function resetModal() {
         btn-solid mxa mt-5
         @click="submitReport()"
       >
-        Submit Report
+        {{ $t('report.submit') }}
       </button>
     </template>
 
     <template v-else-if="step === 'furtherActions'">
       <h1 mxa text-4xl mb4>
-        {{ reportReason === 'dontlike' ? "Don't want to see this?" : "Thanks for reporting, we'll look into this." }}
+        {{ reportReason === 'dontlike' ? $t('report.further_actions.limit.title') : $t('report.further_actions.report.title') }}
       </h1>
       <p text-xl>
-        {{ reportReason === 'dontlike' ? "Here are your options for controlling what you see:" : "While we review this, here are the actions you can take:" }}
+        {{ reportReason === 'dontlike' ? $t('report.further_actions.limit.description') : $t('report.further_actions.report.description') }}
       </p>
 
       <div v-if="useRelationship(account).value?.following">
         <button btn-outline mxa mt-4 mb-2 @click="unfollow()">
-          Unfollow <b>@{{ account.acct }}</b>
+          <i18n-t keypath="menu.unfollow_account">
+            <b>@{{ account.acct }}</b>
+          </i18n-t>
         </button><br>
-        You will no longer see posts from this user in your home feed. You may still see posts from them elsewhere.
+        {{ $t('report.unfollow_desc') }}
       </div>
       <div v-if="!useRelationship(account).value?.muting">
         <button btn-outline mxa mt-4 mb-2 @click="mute()">
-          Mute <b>@{{ account.acct }}</b>
+          <i18n-t keypath="menu.mute_account">
+            <b>@{{ account.acct }}</b>
+          </i18n-t>
         </button><br>
-        You will no longer see any posts from this user. They can still follow you and see your posts. They will not know that they are muted.
+        {{ $t('report.mute_desc') }}
       </div>
       <div v-if="!useRelationship(account).value?.blocking">
         <button btn-outline mxa mt-4 mb-2 @click="block()">
-          Block <b>@{{ account.acct }}</b>
+          <i18n-t keypath="menu.block_account">
+            <b>@{{ account.acct }}</b>
+          </i18n-t>
         </button><br>
-        You will no longer see any posts from this user. They will not be able to see your posts or follow you. They will be able to tell that they are blocked.
+        {{ $t('report.block_desc') }}
       </div>
       <button btn-solid mxa mt-10 @click="emit('close')">
-        Done
+        {{ $t('action.done') }}
       </button>
     </template>
   </div>

--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -48,12 +48,6 @@ async function copyLink(status: mastodon.v1.Status) {
     await clipboard.copy(url)
 }
 
-async function copyOriginalLink(status: mastodon.v1.Status) {
-  const url = status.url
-  if (url)
-    await clipboard.copy(url)
-}
-
 const { share, isSupported: isShareSupported } = useShare()
 async function shareLink(status: mastodon.v1.Status) {
   const url = getPermalinkUrl(status)
@@ -191,13 +185,6 @@ function showFavoritedAndBoostedBy() {
         />
 
         <CommonDropdownItem
-          :text="$t('menu.copy_original_link_to_post')"
-          icon="i-ri:links-fill"
-          :command="command"
-          @click="copyOriginalLink(status)"
-        />
-
-        <CommonDropdownItem
           v-if="isShareSupported"
           :text="$t('menu.share_post')"
           icon="i-ri:share-line"
@@ -213,14 +200,6 @@ function showFavoritedAndBoostedBy() {
           :disabled="isLoading.muted"
           @click="toggleMute()"
         />
-
-        <NuxtLink v-if="status.url" :to="status.url" external target="_blank">
-          <CommonDropdownItem
-            :text="$t('menu.open_in_original_site')"
-            icon="i-ri:arrow-right-up-line"
-            :command="command"
-          />
-        </NuxtLink>
 
         <template v-if="isHydrated && currentUser">
           <template v-if="isAuthor">
@@ -290,6 +269,13 @@ function showFavoritedAndBoostedBy() {
               icon="i-ri:checkbox-circle-line"
               :command="command"
               @click="toggleBlockAccount(useRelationship(status.account).value!, status.account)"
+            />
+
+            <CommonDropdownItem
+              :text="$t('menu.report_account', [`@${status.account.acct}`])"
+              icon="i-ri:flag-2-line"
+              :command="command"
+              @click="openReportDialog(status.account, status)"
             />
           </template>
         </template>

--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -48,6 +48,14 @@ async function copyLink(status: mastodon.v1.Status) {
     await clipboard.copy(url)
 }
 
+/*
+async function copyOriginalLink(status: mastodon.v1.Status) {
+  const url = status.url
+  if (url)
+    await clipboard.copy(url)
+}
+*/
+
 const { share, isSupported: isShareSupported } = useShare()
 async function shareLink(status: mastodon.v1.Status) {
   const url = getPermalinkUrl(status)
@@ -184,6 +192,13 @@ function showFavoritedAndBoostedBy() {
           @click="copyLink(status)"
         />
 
+        <!-- <CommonDropdownItem
+          :text="$t('menu.copy_original_link_to_post')"
+          icon="i-ri:links-fill"
+          :command="command"
+          @click="copyOriginalLink(status)"
+        /> -->
+
         <CommonDropdownItem
           v-if="isShareSupported"
           :text="$t('menu.share_post')"
@@ -200,6 +215,14 @@ function showFavoritedAndBoostedBy() {
           :disabled="isLoading.muted"
           @click="toggleMute()"
         />
+
+        <!-- <NuxtLink v-if="status.url" :to="status.url" external target="_blank">
+          <CommonDropdownItem
+            :text="$t('menu.open_in_original_site')"
+            icon="i-ri:arrow-right-up-line"
+            :command="command"
+          />
+        </NuxtLink> -->
 
         <template v-if="isHydrated && currentUser">
           <template v-if="isAuthor">

--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
+import { toggleBlockAccount, toggleMuteAccount, useRelationship } from '~~/composables/masto/relationship'
 
 const props = defineProps<{
   status: mastodon.v1.Status
@@ -259,6 +260,36 @@ function showFavoritedAndBoostedBy() {
               icon="i-ri:at-line"
               :command="command"
               @click="mentionUser(status.account)"
+            />
+
+            <CommonDropdownItem
+              v-if="!useRelationship(status.account).value?.muting"
+              :text="$t('menu.mute_account', [`@${status.account.acct}`])"
+              icon="i-ri:volume-mute-line"
+              :command="command"
+              @click="toggleMuteAccount(useRelationship(status.account).value!, status.account)"
+            />
+            <CommonDropdownItem
+              v-else
+              :text="$t('menu.unmute_account', [`@${status.account.acct}`])"
+              icon="i-ri:volume-up-fill"
+              :command="command"
+              @click="toggleMuteAccount(useRelationship(status.account).value!, status.account)"
+            />
+
+            <CommonDropdownItem
+              v-if="!useRelationship(status.account).value?.blocking"
+              :text="$t('menu.block_account', [`@${status.account.acct}`])"
+              icon="i-ri:forbid-2-line"
+              :command="command"
+              @click="toggleBlockAccount(useRelationship(status.account).value!, status.account)"
+            />
+            <CommonDropdownItem
+              v-else
+              :text="$t('menu.unblock_account', [`@${status.account.acct}`])"
+              icon="i-ri:checkbox-circle-line"
+              :command="command"
+              @click="toggleBlockAccount(useRelationship(status.account).value!, status.account)"
             />
           </template>
         </template>

--- a/composables/dialog.ts
+++ b/composables/dialog.ts
@@ -12,6 +12,9 @@ export const mediaPreviewIndex = ref(0)
 export const statusEdit = ref<mastodon.v1.StatusEdit>()
 export const dialogDraftKey = ref<string>()
 
+export const reportAccount = ref<mastodon.v1.Account>()
+export const reportStatus = ref<mastodon.v1.Status>()
+
 export const commandPanelInput = ref('')
 
 export const isFirstVisit = useLocalStorage(STORAGE_KEY_FIRST_VISIT, !process.mock)
@@ -26,6 +29,7 @@ export const isCommandPanelOpen = ref(false)
 export const isConfirmDialogOpen = ref(false)
 export const isErrorDialogOpen = ref(false)
 export const isFavouritedBoostedByDialogOpen = ref(false)
+export const isReportDialogOpen = ref(false)
 
 export const lastPublishDialogStatus = ref<mastodon.v1.Status | null>(null)
 
@@ -147,4 +151,14 @@ export function toggleKeyboardShortcuts() {
 
 export function closeKeyboardShortcuts() {
   isKeyboardShortcutsDialogOpen.value = false
+}
+
+export function openReportDialog(account: mastodon.v1.Account, status?: mastodon.v1.Status) {
+  reportAccount.value = account
+  reportStatus.value = status
+  isReportDialogOpen.value = true
+}
+
+export function closeReportDialog() {
+  isReportDialogOpen.value = false
 }

--- a/composables/masto/relationship.ts
+++ b/composables/masto/relationship.ts
@@ -31,3 +31,52 @@ async function fetchRelationships() {
   for (let i = 0; i < requested.length; i++)
     requested[i][1].value = relationships[i]
 }
+
+export async function toggleMuteAccount(relationship: mastodon.v1.Relationship, account: mastodon.v1.Account) {
+  const { client } = $(useMasto())
+  const i18n = useNuxtApp().$i18n
+
+  if (!relationship!.muting && await openConfirmDialog({
+    title: i18n.t('confirm.mute_account.title', [account.acct]),
+    confirm: i18n.t('confirm.mute_account.confirm'),
+    cancel: i18n.t('confirm.mute_account.cancel'),
+  }) !== 'confirm')
+    return
+
+  relationship!.muting = !relationship!.muting
+  relationship = relationship!.muting
+    ? await client.v1.accounts.mute(account.id, {
+      // TODO support more options
+    })
+    : await client.v1.accounts.unmute(account.id)
+}
+
+export async function toggleBlockAccount(relationship: mastodon.v1.Relationship, account: mastodon.v1.Account) {
+  const { client } = $(useMasto())
+  const i18n = useNuxtApp().$i18n
+
+  if (!relationship!.blocking && await openConfirmDialog({
+    title: i18n.t('confirm.block_account.title', [account.acct]),
+    confirm: i18n.t('confirm.block_account.confirm'),
+    cancel: i18n.t('confirm.block_account.cancel'),
+  }) !== 'confirm')
+    return
+
+  relationship!.blocking = !relationship!.blocking
+  relationship = await client.v1.accounts[relationship!.blocking ? 'block' : 'unblock'](account.id)
+}
+
+export async function toggleBlockDomain(relationship: mastodon.v1.Relationship, account: mastodon.v1.Account) {
+  const { client } = $(useMasto())
+  const i18n = useNuxtApp().$i18n
+
+  if (!relationship!.domainBlocking && await openConfirmDialog({
+    title: i18n.t('confirm.block_domain.title', [getServerName(account)]),
+    confirm: i18n.t('confirm.block_domain.confirm'),
+    cancel: i18n.t('confirm.block_domain.cancel'),
+  }) !== 'confirm')
+    return
+
+  relationship!.domainBlocking = !relationship!.domainBlocking
+  await client.v1.domainBlocks[relationship!.domainBlocking ? 'block' : 'unblock'](getServerName(account))
+}

--- a/composables/masto/relationship.ts
+++ b/composables/masto/relationship.ts
@@ -32,6 +32,22 @@ async function fetchRelationships() {
     requested[i][1].value = relationships[i]
 }
 
+export async function toggleFollowAccount(relationship: mastodon.v1.Relationship, account: mastodon.v1.Account) {
+  const { client } = $(useMasto())
+  const i18n = useNuxtApp().$i18n
+
+  if (relationship!.following) {
+    if (await openConfirmDialog({
+      title: i18n.t('confirm.unfollow.title'),
+      confirm: i18n.t('confirm.unfollow.confirm'),
+      cancel: i18n.t('confirm.unfollow.cancel'),
+    }) !== 'confirm')
+      return
+  }
+  relationship!.following = !relationship!.following
+  relationship = await client.v1.accounts[relationship!.following ? 'follow' : 'unfollow'](account.id)
+}
+
 export async function toggleMuteAccount(relationship: mastodon.v1.Relationship, account: mastodon.v1.Account) {
   const { client } = $(useMasto())
   const i18n = useNuxtApp().$i18n

--- a/locales/en.json
+++ b/locales/en.json
@@ -243,6 +243,7 @@
     "open_in_original_site": "Open in original site",
     "pin_on_profile": "Pin on profile",
     "remove_personal_note": "Remove personal note from {0}",
+    "report_account": "Report {0}",
     "share_post": "Share this post",
     "show_favourited_and_boosted_by": "Show who favorited and boosted",
     "show_reblogs": "Show boosts from {0}",

--- a/locales/en.json
+++ b/locales/en.json
@@ -55,6 +55,7 @@
     "close": "Close",
     "compose": "Compose",
     "confirm": "Confirm",
+    "done": "Done",
     "edit": "Edit",
     "enter_app": "Enter App",
     "favourite": "Favorite",
@@ -255,6 +256,7 @@
     "translate_post": "Translate post",
     "unblock_account": "Unblock {0}",
     "unblock_domain": "Unblock domain {0}",
+    "unfollow_account": "Unfollow {0}",
     "unmute_account": "Unmute {0}",
     "unmute_conversation": "Unmute this post",
     "unpin_on_profile": "Unpin on profile"
@@ -337,6 +339,42 @@
         "short_name": "Elk"
       }
     }
+  },
+  "report": {
+    "additional_comments": "Additional comments",
+    "another_server": "The user you're reporting is from another server",
+    "anything_else": "Is there anything else you think we should know?",
+    "block_desc": "You will no longer see any posts from this user. They will not be able to see your posts or follow you. They will be able to tell that they are blocked.",
+    "dontlike": "I don't like it",
+    "dontlike_desc": "It is not something you want to see",
+    "forward": "Yes, forward this report to {0}",
+    "forward_question": "Do you want to send an anonymized copy of this report to that server as well?",
+    "further_actions": {
+      "limit": {
+        "description": "Here are your options for controlling what you see:",
+        "title": "Don't want to see this?"
+      },
+      "report": {
+        "description": "While we review this, here are the actions you can take:",
+        "title": "Thanks for reporting, we'll look into this."
+      }
+    },
+    "limiting": "Limiting {0}",
+    "mute_desc": "You will no longer see any posts from this user. They can still follow you and see your posts. They will not know that they are muted.",
+    "other": "It's something else",
+    "other_desc": "The issue does not fit into other categories",
+    "reporting": "Reporting {0}",
+    "select_many": "Select all that apply:",
+    "select_one": "Choose the best match:",
+    "select_posts": "Are there any posts that back up this report?",
+    "select_posts_other": "Are there any other posts that back up this report?",
+    "spam": "It's spam",
+    "spam_desc": "Malicious links, fake engagement, or repetitive replies",
+    "submit": "Submit Report",
+    "unfollow_desc": "You will no longer see posts from this user in your home feed. You may still see posts from them elsewhere.",
+    "violation": "It violates one or more of the server rules",
+    "whats_wrong_account": "Tell us what's wrong with this account",
+    "whats_wrong_post": "Tell us what's wrong with this post"
   },
   "search": {
     "search_desc": "Search for people & hashtags",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -103,7 +103,7 @@ export default defineNuxtConfig({
       translateApi: '',
       // Use the instance where Elk has its Mastodon account as the default
       defaultServer: 'mozilla.social',
-      singleInstance: true,
+      singleInstance: false,
     },
     storage: {
       fsBase: 'node_modules/.cache/app',


### PR DESCRIPTION
- Adds a "Report" button to the context menu of posts and account pages
- Adds "Mute" and "Block" to the context menu of posts
- Removes "Copy Original Link" and "Open in Original Site" options from the context menu of posts
- Adds a two-step modal dialog for reporting
    - First step: select categories, rules, add additional comment, and (if applicable) choose whether to forward the report
    - Second step: thank you screen with optional "self-moderating" actions
    - Note that "I don't like this" takes you straight to the second step without filing a report (same behavior as stock Mastodon). The dialog title changes from "Reporting..." to "Limiting..." to reflect this shift.

Missing i18n for now. Not sure what our plan should be for that.

NB: this PR supersedes [my previous one](https://github.com/mozilla/elk/pull/1) dealing with context menu actions (see my comment in the other PR)

JIRA: https://mozilla-hub.atlassian.net/browse/MZTDN-176