### PR TITLE
fix(switcher): removing the ability to add an account in the switcher

### DIFF
--- a/components/user/UserSwitcher.vue
+++ b/components/user/UserSwitcher.vue
@@ -34,6 +34,7 @@ function processSignIn() {
   <div sm:min-w-80 max-w-100vw mxa py2 flex="~ col" @click="emit('click')">
     <template v-for="user of sorted" :key="user.id">
       <button
+        v-if="!singleInstanceServer"
         flex rounded px4 py3 text-left
         hover:bg-active cursor-pointer transition-100
         aria-label="Switch user"
@@ -44,9 +45,10 @@ function processSignIn() {
         <div v-if="user.token === currentUser?.token" i-ri:check-line text-primary mya text-2xl />
       </button>
     </template>
-    <div border="t base" pt2>
+    <div :border="singleInstanceServer ? 'base' : 't base'" pt2>
       <CommonDropdownItem
         is="button"
+        v-if="!singleInstanceServer"
         :text="$t('user.add_existing')"
         icon="i-ri:user-add-line"
         w-full


### PR DESCRIPTION
## Goal 

When we are in single instance mode, hide the ability to select or add another user.

<img width="589" alt="Screenshot 2023-08-02 at 8 14 25 PM" src="https://github.com/MozillaSocial/elk/assets/1010384/38dcb4c3-cf68-4361-909f-404bbcd29d4f">
