### PR TITLE
fix(footer): remove unnecessary info from footer

### DIFF
--- a/components/nav/NavFooter.vue
+++ b/components/nav/NavFooter.vue
@@ -1,11 +1,5 @@
 <script setup lang="ts">
-const buildInfo = useBuildInfo()
-const timeAgoOptions = useTimeAgoOptions()
-const config = useRuntimeConfig()
 const userSettings = useUserSettings()
-
-const buildTimeDate = new Date(buildInfo.time)
-const buildTimeAgo = useTimeAgo(buildTimeDate, timeAgoOptions)
 
 const colorMode = useColorMode()
 function toggleDark() {
@@ -28,69 +22,6 @@ function toggleDark() {
           @click="togglePreferences('zenMode')"
         />
       </CommonTooltip>
-      <CommonTooltip :content="$t('settings.about.sponsor_action')">
-        <NuxtLink
-          flex
-          text-lg
-          i-ri-heart-3-line hover="i-ri-heart-3-fill text-rose"
-          :aria-label="$t('settings.about.sponsor_action')"
-          href="https://github.com/sponsors/elk-zone"
-          target="_blank"
-        />
-      </CommonTooltip>
-    </div>
-    <div>
-      <i18n-t v-if="isHydrated" keypath="nav.built_at">
-        <time :datetime="String(buildTimeDate)" :title="$d(buildTimeDate, 'long')">{{ buildTimeAgo }}</time>
-      </i18n-t>
-      <span v-else>
-        {{ $t('nav.built_at', [$d(buildTimeDate, 'shortDate')]) }}
-      </span>
-      &middot;
-      <NuxtLink
-        v-if="buildInfo.env === 'release'"
-        external
-        :href="`https://github.com/elk-zone/elk/releases/tag/v${buildInfo.version}`"
-        target="_blank"
-        font-mono
-      >
-        v{{ buildInfo.version }}
-      </NuxtLink>
-      <span v-else>{{ buildInfo.env }}</span>
-      <template v-if="buildInfo.commit && buildInfo.branch !== 'release'">
-        &middot;
-        <NuxtLink
-          external
-          :href="`https://github.com/elk-zone/elk/commit/${buildInfo.commit}`"
-          target="_blank"
-          font-mono
-        >
-          {{ buildInfo.shortCommit }}
-        </NuxtLink>
-      </template>
-    </div>
-    <div>
-      <NuxtLink cursor-pointer hover:underline to="/settings/about">
-        {{ $t('settings.about.label') }}
-      </NuxtLink>
-      <template v-if="config.public.privacyPolicyUrl">
-        &middot;
-        <NuxtLink cursor-pointer hover:underline :to="config.public.privacyPolicyUrl">
-          {{ $t('nav.privacy') }}
-        </NuxtLink>
-      </template>
-      &middot;
-      <NuxtLink href="/m.webtoo.ls/@elk" target="_blank">
-        Mastodon
-      </NuxtLink>
-      &middot;
-      <NuxtLink href="https://chat.elk.zone" target="_blank" external>
-        Discord
-      </NuxtLink>
-      &middot;
-      <NuxtLink href="https://github.com/elk-zone/elk" target="_blank" external>
-        GitHub
-      </NuxtLink>
     </div>
   </footer>
 </template>


### PR DESCRIPTION
[SOCIALPLAT-96](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-96)

Removed from footer:
- [x] Sponsor us heart icon
- [x] Build info line
- [x] Info links line

---

Note: I wanted to make sure I had the repo all set up locally, could make changes, and had all the correct commit/push rights, so I kinda went rogue and just took a ticket and ran with it. I'll chat with the team next week about whether we want to close this PR or let it in.