### PR TITLE
fix(prerender): remove the pre-rendering of lists since it uses masto

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -113,6 +113,7 @@ export default defineNuxtConfig({
   routeRules: {
     // Static generation
     '/': { prerender: true },
+    '/lists': { prerender: false },
     '/settings/**': { prerender: false },
     // incremental regeneration
     '/api/list-servers': { swr: true },


### PR DESCRIPTION
## Goal

Masto is used on pre-rendering lists. Disabling that for now.