### PR TITLE
fix(settings): Rename Account Settings to Advanced Settings

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -410,8 +410,8 @@
       "version": "Version"
     },
     "account_settings": {
-      "description": "Edit your account settings in Mastodon UI",
-      "label": "Account settings"
+      "description": "Edit Mastodon preferences",
+      "label": "Advanced settings"
     },
     "interface": {
       "color_mode": "Color Mode",


### PR DESCRIPTION
[SOCIALPLAT-461](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-461)

Rename
- [x] “Accounts settings” to “Advanced settings”
- [x] Description to “Edit Mastodon preferences”

Before:
<img width="722" alt="image" src="https://github.com/MozillaSocial/elk/assets/14023085/592efc17-352c-4c45-8b03-91121ad56b55">


After:
<img width="618" alt="image" src="https://github.com/MozillaSocial/elk/assets/14023085/d14021ba-d3b2-4722-87a1-7e9b096491a2">
