### PR TITLE
fix(error pages): add specific copy for 404 & 500 errors

### DIFF
--- a/error.vue
+++ b/error.vue
@@ -9,15 +9,15 @@ const { error } = defineProps<{
 const { t } = useI18n()
 // add more custom status codes messages here
 const errorCodes: Record<number, string> = {
-  404: t('Sorry, we can\'t find that page'),
-  500: t('Sorry, something went wrong'),
+  404: t('error.message-404'),
+  500: t('error.message-500'),
 }
 
 if (process.dev)
   console.error(error)
 
-const defaultMessage = t('Something went wrong')
-const subtitle = t('We\'re all about a healthy internet but sometimes broken URLs happen.')
+const defaultMessage = t('error.message-default')
+const subtitle = t('error.message-subtitle')
 const message = errorCodes[error.statusCode!] ?? error.message ?? defaultMessage
 const showBack = error.statusCode === 404
 </script>

--- a/error.vue
+++ b/error.vue
@@ -8,27 +8,16 @@ const { error } = defineProps<{
 
 // add more custom status codes messages here
 const errorCodes: Record<number, string> = {
-  404: 'Page not found',
+  404: 'Sorry, we can\'t find that page',
+  500: 'Sorry, something went wrong',
 }
 
 if (process.dev)
   console.error(error)
 
 const defaultMessage = 'Something went wrong'
-
-const message = error.message ?? errorCodes[error.statusCode!] ?? defaultMessage
-
-const state = ref<'error' | 'reloading'>('error')
-async function reload() {
-  state.value = 'reloading'
-  try {
-    clearError({ redirect: currentUser.value ? '/home' : `/${currentServer.value}/public/local` })
-  }
-  catch (err) {
-    console.error(err)
-    state.value = 'error'
-  }
-}
+const subtitle = 'We\'re all about a healthy internet but sometimes broken URLs happen.'
+const message = errorCodes[error.statusCode!] ?? error.message ?? defaultMessage
 </script>
 
 <template>
@@ -39,20 +28,21 @@ async function reload() {
         <span timeline-title-style>Error</span>
       </template>
       <slot>
-        <form p5 grid gap-y-4 @submit="reload">
-          <div text-lg>
-            Something went wrong
-          </div>
-          <div text-secondary>
+        <div p5 grid gap-y-4>
+          <div text-xl font-bold>
             {{ message }}
           </div>
-          <button flex items-center gap-2 justify-center btn-solid text-center :disabled="state === 'reloading'">
-            <span v-if="state === 'reloading'" block animate-spin preserve-3d>
-              <span block i-ri:loader-2-fill />
-            </span>
-            {{ state === 'reloading' ? 'Reloading' : 'Reload' }}
-          </button>
-        </form>
+          <div text-secondary>
+            {{ subtitle }}
+          </div>
+          <NuxtLink
+            :aria-label="$t('nav.back')"
+            class="btn-text inline-flex flex-items-center -ml-5"
+            @click="$router.go(-1)"
+          >
+            <span i-ri:arrow-left-line /> {{ $t('nav.back') }}
+          </NuxtLink>
+        </div>
       </slot>
     </MainContent>
   </NuxtLayout>

--- a/error.vue
+++ b/error.vue
@@ -19,6 +19,7 @@ if (process.dev)
 const defaultMessage = t('Something went wrong')
 const subtitle = t('We\'re all about a healthy internet but sometimes broken URLs happen.')
 const message = errorCodes[error.statusCode!] ?? error.message ?? defaultMessage
+const showBack = error.statusCode === 404
 </script>
 
 <template>
@@ -37,6 +38,7 @@ const message = errorCodes[error.statusCode!] ?? error.message ?? defaultMessage
             {{ subtitle }}
           </div>
           <NuxtLink
+            v-if="showBack"
             :aria-label="$t('nav.back')"
             class="btn-text inline-flex flex-items-center -ml-5"
             @click="$router.go(-1)"

--- a/error.vue
+++ b/error.vue
@@ -6,17 +6,18 @@ const { error } = defineProps<{
   error: Partial<NuxtError>
 }>()
 
+const { t } = useI18n()
 // add more custom status codes messages here
 const errorCodes: Record<number, string> = {
-  404: 'Sorry, we can\'t find that page',
-  500: 'Sorry, something went wrong',
+  404: t('Sorry, we can\'t find that page'),
+  500: t('Sorry, something went wrong'),
 }
 
 if (process.dev)
   console.error(error)
 
-const defaultMessage = 'Something went wrong'
-const subtitle = 'We\'re all about a healthy internet but sometimes broken URLs happen.'
+const defaultMessage = t('Something went wrong')
+const subtitle = t('We\'re all about a healthy internet but sometimes broken URLs happen.')
 const message = errorCodes[error.statusCode!] ?? error.message ?? defaultMessage
 </script>
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -163,6 +163,10 @@
     "account_not_found": "Account {0} not found",
     "explore-list-empty": "Nothing is trending right now. Check back later!",
     "file_size_cannot_exceed_n_mb": "File size cannot exceed {0}MB",
+    "message-404": "Sorry, we can't find that page",
+    "message-500": "Sorry, something went wrong",
+    "message-default": "Something went wrong",
+    "message-subtitle": "We're all about a healthy internet but sometimes broken URLs happen.",
     "sign_in_error": "Cannot connect to the server.",
     "status_not_found": "Post not found",
     "unsupported_file_format": "Unsupported file format"

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -6,9 +6,6 @@ definePageMeta({
   alias: ['/signin/callback'],
 })
 
-// if (true)
-//   throw createError({ statusCode: 500, statusMessage: 'Internal Server Error' })
-
 const route = useRoute()
 const router = useRouter()
 if (process.client && route.path === '/signin/callback')

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -6,6 +6,9 @@ definePageMeta({
   alias: ['/signin/callback'],
 })
 
+// if (true)
+//   throw createError({ statusCode: 500, statusMessage: 'Internal Server Error' })
+
 const route = useRoute()
 const router = useRouter()
 if (process.client && route.path === '/signin/callback')


### PR DESCRIPTION
[SOCIALPLAT-396](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-396)

- [x] update `error.vue` to include specific messages for 404 and 500 errors
- [x] replace the `Reload` button with a `<- Go back` link (only for the 404 page)

**Some things I'd like some help on**:
1. I'm seeing a FOUC _sometimes_ when navigating back and forth between the 404 page and other pages. It doesn't happen every time and I can't nail down why it's happening.
    - Update: After some additional investigating and chatting with @collectedmind, we've decided to not focus on fixing the FOUC right now. It's unclear whether this is an issue that will occur in the staging and production environments or is simply happening on localhost. Once this is deployed, we can do additional testing and investigate further if needed.  
3. I tried a few different ways to force a 500 error so I could test it, but I wasn't able to find a good one, so I just threw a javascript error in the home template and [formatted the data](https://nuxt.com/docs/getting-started/error-handling#rendering-an-error-page) to match the `NuxtError`.
4. Is everyone else's localhost loading this slow (see gifs below)?
