### PR TITLE
fix(settings): remove unneeded elk settings

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -449,7 +449,7 @@
           "reblog": "Reblog your post",
           "title": "What notifications to receive?"
         },
-        "description": "Receive notifications even when you are not using Elk.",
+        "description": "Receive notifications even when you are not using Mozilla.social.",
         "instructions": "Don't forget to save your changes using @:settings.notifications.push_notifications.save_settings button!",
         "label": "Push notifications settings",
         "policy": {

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -65,13 +65,6 @@ const isRootPath = computedEager(() => route.name === 'settings')
             />
             <SettingsItem
               command
-              icon="i-ri-group-line"
-              :text="isHydrated ? $t('settings.users.label') : ''"
-              to="/settings/users"
-              :match="$route.path.startsWith('/settings/users/')"
-            />
-            <SettingsItem
-              command
               icon="i-ri:information-line"
               :text="isHydrated ? $t('settings.about.label') : ''"
               to="/settings/about"

--- a/pages/settings/language/index.vue
+++ b/pages/settings/language/index.vue
@@ -24,9 +24,6 @@ const status = computed(() => {
     <div p6>
       <label space-y-2>
         <span block font-medium>{{ $t('settings.language.display_language') }}</span>
-        <span block>
-          {{ status }}
-        </span>
         <SettingsLanguage select-settings />
       </label>
       <h2 py4 mt2 font-bold text-xl flex="~ gap-1" items-center>

--- a/pages/settings/notifications/index.vue
+++ b/pages/settings/notifications/index.vue
@@ -21,11 +21,6 @@ useHydratedHead({
 
     <SettingsItem
       command
-      :text="isHydrated ? $t('settings.notifications.notifications.label') : ''"
-      to="/settings/notifications/notifications"
-    />
-    <SettingsItem
-      command
       :disabled="!pwaEnabled"
       :text="isHydrated ? $t('settings.notifications.push_notifications.label') : ''"
       :description="isHydrated ? $t('settings.notifications.push_notifications.description') : ''"

--- a/pages/settings/profile/index.vue
+++ b/pages/settings/profile/index.vue
@@ -26,22 +26,6 @@ useHydratedHead({
       to="/settings/profile/appearance"
     />
     <SettingsItem
-      command large
-      icon="i-ri:hashtag"
-      :text="isHydrated ? $t('settings.profile.featured_tags.label') : ''"
-      :description="isHydrated ? $t('settings.profile.featured_tags.description') : ''"
-      to="/settings/profile/featured-tags"
-    />
-    <SettingsItem
-      v-if="isHydrated && currentUser"
-      command large
-      icon="i-ri:settings-line"
-      :text="$t('settings.account_settings.label')"
-      :description="$t('settings.account_settings.description')"
-      :to="`https://${currentUser!.server}/auth/edit`"
-      external target="_blank"
-    />
-    <SettingsItem
       v-if="isHydrated && currentUser"
       command large
       icon="i-ri:settings-3-line"


### PR DESCRIPTION
[SOCIALPLAT-465](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-465)

- [x] “Profile” - “Featured Hashtags” has been removed
- [x] “Profile” - Advanced Settings has been removed
- [x] “Notifications” - “Notifications Settings” has been removed
- [x] "Translation status..." has been removed 
- [x] “Logged in users” has been removed
- [x] “Elk” in the description for “Push Notification Settings” has been changed to “Mozilla.social”

I did not remove any pages or functions related to these buttons as it seemed like there's a chance some may come back (plus we're not doing any unnecessary cleanup for the ASAP phase)