### PR TITLE
fix(beta labels): move styles to unocss data attributes

### DIFF
--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -44,7 +44,7 @@ const containerClass = computed(() => {
           </NuxtLink>
           <div :truncate="!noOverflowHidden ? '' : false" flex w-full data-tauri-drag-region class="native-mac:justify-center native-mac:text-center native-mac:sm:justify-start">
             <slot name="title" />
-            <div v-if="!noBetaLabel" ml-12px font-700 class="beta">
+            <div v-if="!noBetaLabel" text-primary font-700 p-x-6px p-y-5px ml-12px border-2 border-primary b-rd-8px>
               Beta
             </div>
           </div>
@@ -68,12 +68,3 @@ const containerClass = computed(() => {
     </div>
   </div>
 </template>
-
-<style>
-  .beta {
-    padding: 5px 6px;
-    border-radius: 8px;
-    border: 2px solid var(--c-primary);
-    color: var(--c-primary);
-  }
-</style>

--- a/components/nav/NavFooter.vue
+++ b/components/nav/NavFooter.vue
@@ -11,7 +11,7 @@ function toggleDark() {
 
 <template>
   <footer p4 text-sm text-secondary-light flex="~ col">
-    <div mb-15px p10px font-500 class="beta-label">
+    <div bg-primary text-base-light font-500 p-10px mb-15px w-212px b-rd-8px>
       <i18n-t keypath="footer.beta.description">
         <b>{{ $t('footer.beta.desc_1') }}</b>
         <NuxtLink href="https://survey.alchemer.com/s3/7470063/mozilla-social-feedback-form" target="_blank" external>
@@ -48,12 +48,3 @@ function toggleDark() {
     </div>
   </footer>
 </template>
-
-<style>
-  .beta-label {
-    width: 212px;
-    background-color: var(--c-primary);
-    border-radius: 8px;
-    color: var(--c-text-base-light);
-  }
-</style>

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
       'text-inverted': 'text-$c-bg-base',
       'text-secondary': 'text-$c-text-secondary',
       'text-secondary-light': 'text-$c-text-secondary-light',
+      'text-base-light': 'text-$c-text-base-light',
 
       // buttons
       'btn-base': 'cursor-pointer disabled:pointer-events-none disabled:bg-$c-bg-btn-disabled disabled:text-$c-text-btn-disabled',


### PR DESCRIPTION
Wanted to explore how easy it was to convert custom styles to UnoCSS attributes. Turns out, it's not too terrible. I've documented some learnings below and I would love to do a brownbag/lunch & learn about UnoCSS after all hands.

- [x] remove the `<style>` tags for the beta labels and use UnoCSS data attributes instead
- [x] add `text-base-light` shortcut


<details>
  <summary>Some Learnings:</summary>
  
- Custom styles are possible (if you know the magic incantations 🪄 )
  - `width: 212px` becomes `w-212px`
  - `border-radius: 8px` becomes `b-rd-8px`
  - I think a good rule of thumb is that if there is a unit (`px`, `rem`, `em`), then it's a custom value
  - Variables are a-ok but a little confusing (still wrapping my head around how it all works)
- UnoCSS does provide quite a bit of customization via the [config](https://unocss.dev/guide/config-file)
- The [interactive docs](https://unocss.dev/interactive/) are often unhelpful but sometimes your best friend
  - Searching `width` gives you practically nothing useful, but searching `w-212px` shows you the exact code that would be generated
- Both data attributes and classes are okay
  - You just can't apply custom classes directly in the browser and have them be respected - they have to be compiled in order to be generated correctly 
    - Something to be mindful of if you like to style using the browser dev tools like me
</details>


