### PR TITLE
fix(unoCSS config): update text color for btn-solid shortcut

### DIFF
--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
 
       // buttons
       'btn-base': 'cursor-pointer disabled:pointer-events-none disabled:bg-$c-bg-btn-disabled disabled:text-$c-text-btn-disabled',
-      'btn-solid': 'btn-base px-4 py-2 rounded text-$c-text-btn bg-$c-primary hover:bg-$c-primary-active',
+      'btn-solid': 'btn-base px-4 py-2 rounded text-base-light bg-$c-primary hover:bg-$c-primary-active',
       'btn-outline': 'btn-base px-4 py-2 rounded text-$c-primary border border-$c-primary hover:bg-$c-primary hover:text-inverted',
       'btn-text': 'btn-base px-4 py-2 text-$c-primary hover:text-$c-primary-active',
       'btn-action-icon': 'btn-base hover:bg-active rounded-full h9 w9 flex items-center justify-center disabled:bg-transparent disabled:text-$c-text-secondary',


### PR DESCRIPTION
[SOCIALPLAT-506](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-506)

Okay fine, I'll let you have this one UnoCSS. Shortcuts are cool.

<img width="243" alt="Screenshot 2023-08-17 at 5 36 05 PM" src="https://github.com/MozillaSocial/elk/assets/2893463/5f39357b-aa27-4236-bd86-b41fc2093493">
<img width="215" alt="Screenshot 2023-08-17 at 5 36 21 PM" src="https://github.com/MozillaSocial/elk/assets/2893463/ba931088-e7a8-4283-a855-dc4d22d55838">
