### PR TITLE
Add Create Account button

### DIFF
--- a/components/user/UserSignInEntry.vue
+++ b/components/user/UserSignInEntry.vue
@@ -4,24 +4,26 @@ const { busy, oauth, singleInstanceServer } = useSignIn()
 
 <template>
   <div p8 lg:flex="~ col gap2" hidden>
-    <p v-if="isHydrated" text-sm>
-      <i18n-t keypath="user.sign_in_notice_title">
-        <strong>{{ currentServer }}</strong>
-      </i18n-t>
-    </p>
-    <p text-sm text-secondary>
-      {{ $t(singleInstanceServer ? 'user.single_instance_sign_in_desc' : 'user.sign_in_desc') }}
+    <h4 v-if="isHydrated" text-lg font-500>
+      {{ $t('user.sign_in_notice_title') }}
+    </h4>
+    <p text-base mb-4>
+      {{ $t('user.sign_in_desc') }}
     </p>
     <button
       v-if="singleInstanceServer"
-      flex="~ row" gap-x-2 items-center justify-center btn-solid text-center rounded-3
+      flex="~ row" gap-x-2 items-center justify-center btn-solid text-center rounded-3 font-500
+      :disabled="busy"
+      @click="oauth('signup')"
+    >
+      {{ $t('action.create_account') }}
+    </button>
+    <button
+      v-if="singleInstanceServer"
+      flex="~ row" gap-x-2 items-center justify-center btn-outline text-center rounded-3 font-500
       :disabled="busy"
       @click="oauth()"
     >
-      <span v-if="busy" aria-hidden="true" block animate animate-spin preserve-3d class="rtl-flip">
-        <span block i-ri:loader-2-fill aria-hidden="true" />
-      </span>
-      <span v-else aria-hidden="true" block i-ri:login-circle-line class="rtl-flip" />
       {{ $t('action.sign_in') }}
     </button>
     <button v-else btn-solid rounded-3 text-center mt-2 select-none @click="openSigninDialog()">

--- a/composables/sign-in.ts
+++ b/composables/sign-in.ts
@@ -12,7 +12,7 @@ export function useSignIn(input?: Ref<HTMLInputElement | undefined>) {
   const server = ref('')
   const displayError = ref(false)
 
-  async function oauth() {
+  async function oauth(authIntent?: string) {
     if (busy.value)
       return
 
@@ -28,6 +28,9 @@ export function useSignIn(input?: Ref<HTMLInputElement | undefined>) {
     try {
       let href: string
       if (singleInstanceServer) {
+        if (authIntent)
+          localStorage.setItem('mozsoc.auth_intent', authIntent)
+
         href = await (globalThis.$fetch as any)(makeAbsolutePath(`/api/${publicServer.value}/login`), {
           method: 'POST',
           body: {

--- a/locales/en.json
+++ b/locales/en.json
@@ -55,6 +55,7 @@
     "close": "Close",
     "compose": "Compose",
     "confirm": "Confirm",
+    "create_account": "Create account",
     "done": "Done",
     "edit": "Edit",
     "enter_app": "Enter App",
@@ -689,8 +690,8 @@
   "user": {
     "add_existing": "Add an existing account",
     "server_address_label": "Mastodon Server Address",
-    "sign_in_desc": "Sign in to follow profiles or hashtags, favorite, share and reply to posts, or interact from your account on a different server.",
-    "sign_in_notice_title": "Viewing {0} public data",
+    "sign_in_desc": "Sign up to follow profiles and share posts.",
+    "sign_in_notice_title": "New to Mozilla Social?",
     "sign_out_account": "Sign out {0}",
     "single_instance_sign_in_desc": "Sign in to follow profiles or hashtags, favorite, share and reply to posts.",
     "tip_no_account": "If you don't have a Mastodon account yet, {0}.",


### PR DESCRIPTION
Splits the original Sign In button into "Create account" and "Sign in". Both lead to FxA, but create account sets a "signup" intent which causes an interstitial to show.

Also tidied copy and design, as per https://www.figma.com/file/wcdvUdM6RBsQ8hryI2iNlB/ASAP-Elk-Update?node-id=238%3A4793&mode=dev