### PR TITLE
fix(status actions): adjust original link generation

### DIFF
--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -31,10 +31,9 @@ const { t } = useI18n()
 const userSettings = useUserSettings()
 const useStarFavoriteIcon = usePreferences('useStarFavoriteIcon')
 
-const isSingleInstanceServer = useRuntimeConfig().public.singleInstance
 const isAuthor = $computed(() => status.account.id === currentUser.value?.account.id)
 const notLocal = $computed(() => getServerName(status.account) !== currentServer.value)
-const statusRoute = $computed(() => getStatusRoute(status, isSingleInstanceServer))
+const statusRoute = $computed(() => getStatusRoute(status))
 
 const { client } = $(useMasto())
 

--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -51,7 +51,7 @@ async function copyLink() {
     await clipboard.copy(url)
 }
 
-async function copyOriginalLink(status: mastodon.v1.Status) {
+async function copyOriginalLink() {
   const url = status.url
   if (url)
     await clipboard.copy(url)
@@ -198,7 +198,7 @@ function showFavoritedAndBoostedBy() {
           :text="$t('menu.copy_original_link_to_post')"
           icon="i-ri:links-fill"
           :command="command"
-          @click="copyOriginalLink(status)"
+          @click="copyOriginalLink()"
         />
 
         <CommonDropdownItem

--- a/components/status/StatusLink.vue
+++ b/components/status/StatusLink.vue
@@ -8,7 +8,8 @@ const props = defineProps<{
 
 const el = ref<HTMLElement>()
 const router = useRouter()
-const statusRoute = $computed(() => getStatusRoute(props.status))
+const isSingleInstanceServer = useRuntimeConfig().public.singleInstance
+const statusRoute = $computed(() => getStatusRoute(props.status, isSingleInstanceServer))
 
 function onclick(evt: MouseEvent | KeyboardEvent) {
   const path = evt.composedPath() as HTMLElement[]

--- a/components/status/StatusLink.vue
+++ b/components/status/StatusLink.vue
@@ -8,8 +8,7 @@ const props = defineProps<{
 
 const el = ref<HTMLElement>()
 const router = useRouter()
-const isSingleInstanceServer = useRuntimeConfig().public.singleInstance
-const statusRoute = $computed(() => getStatusRoute(props.status, isSingleInstanceServer))
+const statusRoute = $computed(() => getStatusRoute(props.status))
 
 function onclick(evt: MouseEvent | KeyboardEvent) {
   const path = evt.composedPath() as HTMLElement[]

--- a/composables/masto/routes.ts
+++ b/composables/masto/routes.ts
@@ -33,11 +33,11 @@ export function getReportRoute(id: string | number) {
   return `https://${currentUser.value?.server}/admin/reports/${encodeURIComponent(id)}`
 }
 
-export function getStatusRoute(status: mastodon.v1.Status) {
+export function getStatusRoute(status: mastodon.v1.Status, singleInstance?: boolean) {
   return useRouter().resolve({
     name: 'status',
     params: {
-      server: currentServer.value,
+      ...(!singleInstance && { server: currentServer.value }),
       account: extractAccountHandle(status.account),
       status: status.id,
     },

--- a/composables/masto/routes.ts
+++ b/composables/masto/routes.ts
@@ -33,11 +33,12 @@ export function getReportRoute(id: string | number) {
   return `https://${currentUser.value?.server}/admin/reports/${encodeURIComponent(id)}`
 }
 
-export function getStatusRoute(status: mastodon.v1.Status, singleInstance?: boolean) {
+export function getStatusRoute(status: mastodon.v1.Status) {
+  const singleInstanceServer = useRuntimeConfig().public.singleInstance
   return useRouter().resolve({
     name: 'status',
     params: {
-      ...(!singleInstance && { server: currentServer.value }),
+      ...(!singleInstanceServer && { server: currentServer.value }),
       account: extractAccountHandle(status.account),
       status: status.id,
     },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -104,7 +104,7 @@ export default defineNuxtConfig({
       // our default translation server #76
       translateApi: '',
       defaultServer: 'mozilla.social',
-      singleInstance: false,
+      singleInstance: true,
     },
     storage: {
       fsBase: 'node_modules/.cache/app',


### PR DESCRIPTION
## Goal
The copy link functionality was doubling up and making copied links invalid. This adjust things so links behave as expected

## To Do:

- [x] Generate a valid link based on preexisting patterns (clicking on the item)
- [x] BONUS: Limit showing `copy original` on local (mozilla.social) links
- [x] BONUS: Limit showing `open in original` on local (mozilla.social) links


## Implementation Decisions

There was some hoop jumping to generate a link that were (it seems) a remnant of multi-client setup.  Things worked fine locally, but when we put things behind a proxy, some built in redirects broke down.

This uses the built in status link to generate a valid link.  Hard to know what the original intent was given the nature of the repo.

## Feedback

Would love to know if anyone more familiar with this code base to make sure this will not destroy the entire world as we know it.  Dogs and cats, living together ... mass hysteria!

![2023-09-05 09 31 03](https://github.com/MozillaSocial/elk/assets/16119672/1494610b-f153-4776-aa16-d22b7c3cac9e)
