### PR TITLE
use standard 'Sign in' copy for mobile view

### DIFF
--- a/components/nav/NavUser.vue
+++ b/components/nav/NavUser.vue
@@ -26,13 +26,7 @@ const { busy, oauth, singleInstanceServer } = useSignIn()
       :disabled="busy"
       @click="oauth()"
     >
-      <span v-if="busy" aria-hidden="true" block animate animate-spin preserve-3d class="rtl-flip">
-        <span block i-ri:loader-2-fill aria-hidden="true" />
-      </span>
-      <span v-else aria-hidden="true" block i-ri:login-circle-line class="rtl-flip" />
-      <i18n-t keypath="action.sign_in_to">
-        <strong>{{ currentServer }}</strong>
-      </i18n-t>
+      {{ $t('action.sign_in') }}
     </button>
     <button v-else btn-solid text-sm px-2 py-1 text-center xl:hidden @click="openSigninDialog()">
       {{ $t('action.sign_in') }}


### PR DESCRIPTION
When Nuxt config `singleInstance` is set to `true` (as it appears to be on stage/prod), the sign-in button on mobile viewports includes additional server copy.  This causes overlap, especially with the added "Beta" label.

This PR removes the additional server copy, which doesn't seem to appear for desktop views.  Before:
![Screenshot 2023-09-06 at 9 29 02 PM](https://github.com/MozillaSocial/elk/assets/14863500/8d76ea5b-9be4-4039-b6f9-6396c3e01681)

After:
![Screenshot 2023-09-06 at 9 26 59 PM](https://github.com/MozillaSocial/elk/assets/14863500/d544d557-969d-4919-a5e9-0d15cbd678c6)

Ticket: [SOCIALPLAT-554](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-554)
