### PR TITLE
Introduce 'Create account' button on mobile view

### DIFF
--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -33,8 +33,8 @@ const containerClass = computed(() => {
       bg="[rgba(var(--rgb-bg-base),0.7)]"
       class="native:lg:w-[calc(100vw-5rem)] native:xl:w-[calc(135%+(100vw-1200px)/2)]"
     >
-      <div flex justify-between px5 py2 :class="{ 'xl:hidden': $route.name !== 'tag' }" class="native:xl:flex" border="b base">
-        <div flex gap-3 items-center :overflow-hidden="!noOverflowHidden ? '' : false" py2 w-full>
+      <div flex="~ wrap " gap-y-16px justify-between px5 py-16px :class="{ 'xl:hidden': $route.name !== 'tag' }" class="native:xl:flex" border="b base">
+        <div flex gap-3 items-center :overflow-hidden="!noOverflowHidden ? '' : false">
           <NuxtLink
             v-if="backOnSmallScreen || back" flex="~ gap1" items-center btn-text p-0 xl:hidden
             :aria-label="$t('nav.back')"

--- a/components/main/MainContent.vue
+++ b/components/main/MainContent.vue
@@ -33,7 +33,7 @@ const containerClass = computed(() => {
       bg="[rgba(var(--rgb-bg-base),0.7)]"
       class="native:lg:w-[calc(100vw-5rem)] native:xl:w-[calc(135%+(100vw-1200px)/2)]"
     >
-      <div flex="~ wrap " gap-y-16px justify-between px5 py-16px :class="{ 'xl:hidden': $route.name !== 'tag' }" class="native:xl:flex" border="b base">
+      <div flex="~ wrap " gap-y-8px justify-between px5 py-16px :class="{ 'xl:hidden': $route.name !== 'tag' }" class="native:xl:flex" border="b base">
         <div flex gap-3 items-center :overflow-hidden="!noOverflowHidden ? '' : false">
           <NuxtLink
             v-if="backOnSmallScreen || back" flex="~ gap1" items-center btn-text p-0 xl:hidden

--- a/components/nav/NavUser.vue
+++ b/components/nav/NavUser.vue
@@ -19,16 +19,34 @@ const { busy, oauth, singleInstanceServer } = useSignIn()
     </template>
   </VDropdown>
   <template v-else>
-    <button
+    <div
       v-if="singleInstanceServer"
       flex="~ row"
-      gap-x-1 items-center justify-center btn-solid text-sm px-2 py-1 xl:hidden
-      :disabled="busy"
-      @click="oauth()"
+      gap-x-1 items-center justify-center pl-28px pr-2 xl:hidden
     >
-      {{ $t('action.sign_in') }}
-    </button>
-    <button v-else btn-solid text-sm px-2 py-1 text-center xl:hidden @click="openSigninDialog()">
+      <button
+        flex="~ row"
+        mr-8px
+        gap-x-1 items-center justify-center btn-solid text-sm font-600 p-x-11px p-y-11px xl:hidden
+        b-rd-8px
+        :disabled="busy"
+        @click="oauth('signup')"
+      >
+        {{ $t('action.create_account') }}
+      </button>
+      <button
+        flex="~ row"
+        gap-x-1 items-center justify-center text-sm p-x-10px p-y-10px xl:hidden
+        border-1 border-primary btn-outline
+        text-primary text-center font-600
+        b-rd-8px
+        :disabled="busy"
+        @click="oauth()"
+      >
+        {{ $t('action.sign_in') }}
+      </button>
+    </div>
+    <button v-else btn-solid text-sm font-600 p-x-10px p-y-10px text-center xl:hidden @click="openSigninDialog()">
       {{ $t('action.sign_in') }}
     </button>
   </template>

--- a/components/nav/NavUser.vue
+++ b/components/nav/NavUser.vue
@@ -22,13 +22,12 @@ const { busy, oauth, singleInstanceServer } = useSignIn()
     <div
       v-if="singleInstanceServer"
       flex="~ row"
-      gap-x-1 items-center justify-center pl-28px pr-2 xl:hidden
+      gap-x-1 items-center justify-center pl-16px xl:pl-28px sm:pr-2 xl:hidden
     >
       <button
         flex="~ row"
-        mr-8px
-        gap-x-1 items-center justify-center btn-solid text-sm font-600 p-x-11px p-y-11px xl:hidden
-        b-rd-8px
+        gap-x-1 items-center justify-center text-sm p-x-10px p-y-10px xl:hidden text-center font-600
+        sm:mr-8px sm:btn-solid sm:btn-outline
         :disabled="busy"
         @click="oauth('signup')"
       >
@@ -36,10 +35,9 @@ const { busy, oauth, singleInstanceServer } = useSignIn()
       </button>
       <button
         flex="~ row"
-        gap-x-1 items-center justify-center text-sm p-x-10px p-y-10px xl:hidden
-        border-1 border-primary btn-outline
-        text-primary text-center font-600
-        b-rd-8px
+        mr-8px
+        gap-x-1 items-center justify-center text-sm font-600 p-x-11px p-y-11px xl:hidden
+        sm:border-1 sm:border-primary sm:btn-outline sm:b-rd-8px
         :disabled="busy"
         @click="oauth()"
       >

--- a/components/nav/NavUser.vue
+++ b/components/nav/NavUser.vue
@@ -27,7 +27,7 @@ const { busy, oauth, singleInstanceServer } = useSignIn()
       <button
         flex="~ row"
         gap-x-1 items-center justify-center text-sm p-x-10px p-y-10px xl:hidden text-center font-600
-        sm:mr-8px sm:btn-solid sm:btn-outline
+        sm:mr-8px sm:btn-solid sm:btn-outline sm:b-rd-8px
         :disabled="busy"
         @click="oauth('signup')"
       >


### PR DESCRIPTION
[SOCIALPLAT-555](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-555)

## Goal
Mobile view cannot create accounts.

This PR adds a new "Create account" button to the mobile header and adjusts the styling of the existing "Sign In" button.

The new button functions the same way as the [desktop view button added by Ashwin](https://github.com/MozillaSocial/elk/pull/32).

Moiz and I worked together to figure out the sidebar-less version over Zoom

Tablet:
<img width="745" alt="image" src="https://github.com/MozillaSocial/elk/assets/14023085/5247d9bc-4515-4fe6-9421-11169d947de1">

Mobile:
<img width="445" alt="image" src="https://github.com/MozillaSocial/elk/assets/14023085/90d94c3f-55f8-4b0b-a1bf-a25e05509c75">




______________________________________________________

Lesser cool duck-less pictures of light mode:

Tablet:
<img width="673" alt="image" src="https://github.com/MozillaSocial/elk/assets/14023085/7042824d-930f-41ff-b934-5978b33e7475">

Mobile:
<img width="443" alt="image" src="https://github.com/MozillaSocial/elk/assets/14023085/8be18b4d-ceed-43bf-8811-9f3806416dcb">




## I'd love feedback/perspectives on:
- How satisfied are you with UnoCSS on a scale from 1-5?
