### PR TITLE
fix(account settings): add link to mozilla social settings

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -549,9 +549,13 @@
       },
       "fxa_settings": {
         "description": "Change your password and Firefox account preferences",
-        "label": "Account settings"
+        "label": "Firefox account settings"
       },
-      "label": "Profile"
+      "label": "Profile",
+      "moso_settings": {
+        "description": "Manage approved apps, move or delete your Mastodon account",
+        "label": "Mozilla Social account settings"
+      }
     },
     "select_a_settings": "Select a setting",
     "users": {

--- a/pages/settings/profile/index.vue
+++ b/pages/settings/profile/index.vue
@@ -34,5 +34,14 @@ useHydratedHead({
       to="https://accounts.firefox.com/settings"
       external target="_blank"
     />
+    <SettingsItem
+      v-if="isHydrated && currentUser"
+      command large
+      icon="i-ri:settings-3-line"
+      :text="$t('settings.profile.moso_settings.label')"
+      :description="$t('settings.profile.moso_settings.description')"
+      to="https://mozilla.social/auth/edit"
+      external target="_blank"
+    />
   </MainContent>
 </template>


### PR DESCRIPTION
[SOCIALPLAT-600](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-600)

- [x] Rename "Account settings" to "Firefox account settings"
- [x] Add new link for "Mozilla Social account settings" that links to `https://mozilla.social/auth/edit`


<img width="548" alt="Screenshot 2023-09-21 at 12 28 42 PM" src="https://github.com/MozillaSocial/elk/assets/2893463/f8d3c8dd-21f8-40d4-97aa-7536729ab267">
