### PR TITLE
feat(recs): add recs api call and empty discover page [SOC-43, SOC-44]

### DIFF
--- a/components/timeline/TimelineDiscover.vue
+++ b/components/timeline/TimelineDiscover.vue
@@ -6,8 +6,6 @@ const { locale: lang } = useI18n()
 const locale = getLanguageForRecs(lang.value)
 
 const recommendations: Recommendation[] = await $fetch(`/api/recommendations?locale=${locale}`)
-
-// console.log({ recommendations })
 </script>
 
 <template>

--- a/components/timeline/TimelineDiscover.vue
+++ b/components/timeline/TimelineDiscover.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { Recommendation } from '../composables/recommendations'
+import { getLanguageForRecs } from '../../utils/language'
+
+const { locale: lang } = useI18n()
+const locale = getLanguageForRecs(lang.value)
+
+const recommendations: Recommendation[] = await $fetch(`/api/recommendations?locale=${locale}`)
+
+// console.log({ recommendations })
+</script>
+
+<template>
+  <div>
+    Coming soon...
+  </div>
+</template>

--- a/composables/recommendations.ts
+++ b/composables/recommendations.ts
@@ -1,0 +1,22 @@
+/**
+ * Recommendation data
+ * @see https://github.com/Pocket/firefox-api-proxy/blob/main/openapi.yml#L120
+ */
+export interface Recommendation {
+  /** Constant identifier for Recommendation type objects. */
+  __typename: string
+  /** Numerical identifier for the Recommendation. This is specifically a number for Fx client and Mozilla data pipeline compatibility. */
+  tileId: number
+  /** The URL the Recommendation. */
+  url: string
+  /** The title of the Recommendation. */
+  title: string
+  /** An excerpt from the Recommendation. */
+  excerpt: string
+  /** The publisher of the Recommendation. */
+  publisher: string
+  /** The primary image for a Recommendation. */
+  imageUrl: string
+  /** Article read time in minutes */
+  timeToRead: number
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -284,6 +284,7 @@
     "built_at": "Built {0}",
     "compose": "Compose",
     "conversations": "Conversations",
+    "discover": "Discover",
     "explore": "Explore",
     "favourites": "Favorites",
     "federated": "Federated",

--- a/modules/tauri/runtime/nitro.client.ts
+++ b/modules/tauri/runtime/nitro.client.ts
@@ -24,6 +24,10 @@ const handlers = [
     route: '/api/list-servers',
     handler: defineLazyEventHandler(() => import('~/server/api/list-servers').then(r => r.default || r)),
   },
+  {
+    route: '/api/recommendations',
+    handler: defineLazyEventHandler(() => import('~/server/api/recommendations').then(r => r.default || r)),
+  },
 ]
 
 // @ts-expect-error undeclared global window property

--- a/pages/discover.vue
+++ b/pages/discover.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+const { t } = useI18n()
+
+useHydratedHead({
+  title: () => t('nav.discover'),
+})
+</script>
+
+<template>
+  <MainContent>
+    <template #title>
+      <NuxtLink to="/discover" timeline-title-style flex items-center gap-2 @click="$scrollToTop">
+        <div i-ri:earth-line />
+        <span>{{ t('nav.discover') }}</span>
+      </NuxtLink>
+    </template>
+
+    <TimelineDiscover v-if="isHydrated" />
+  </MainContent>
+</template>

--- a/server/api/recommendations.ts
+++ b/server/api/recommendations.ts
@@ -1,0 +1,17 @@
+export default defineEventHandler(async (event) => {
+  try {
+    const { locale } = getQuery(event)
+
+    const recommendations = await fetch(
+      `https://firefox-api-proxy.readitlater.com/desktop/v1/recommendations?consumer_key=moso-web-dev&locale=${locale}`,
+    )
+      .then(response => response.json())
+      .then(response => response.data)
+
+    return recommendations
+  }
+  catch (err) {
+    console.warn(err)
+    return []
+  }
+})

--- a/utils/language.ts
+++ b/utils/language.ts
@@ -28,3 +28,15 @@ export function matchLanguages(languages: string[], acceptLanguages: readonly st
 
   return null
 }
+
+export function getLanguageForRecs(lang: string): string {
+  const availableLocales = [
+    'fr', 'fr-FR',
+    'es', 'es-ES',
+    'it', 'it-IT',
+    'en', 'en-CA', 'en-GB', 'en-US',
+    'de', 'de-DE', 'de-AT', 'de-CH',
+  ]
+
+  return availableLocales.includes(lang) ? lang : 'en'
+}


### PR DESCRIPTION
## Goal

Adding an API endpoint to fetch recommendations and call that API from within an empty discover page

## To Do:

- [x] Add template Discover page
- [x] Add API endpoint to fetch recs
- [x] Add types for recs data
- [x] Add utility function to restrict languages to only the ones the [API allows](https://github.com/Pocket/firefox-api-proxy/blob/main/openapi.yml#L287-L300) 

## Implementation Decisions

Needed to add an internal API endpoint instead of hitting the recs endpoint directly to fetch recs to prevent any CORS issues

## Tickets:
- https://mozilla-hub.atlassian.net/browse/SOC-43
- https://mozilla-hub.atlassian.net/browse/SOC-44