### PR TITLE
Fix account route; remove Original Site option for local accounts

### DIFF
--- a/components/account/AccountMoreButton.vue
+++ b/components/account/AccountMoreButton.vue
@@ -14,6 +14,7 @@ const emit = defineEmits<{
 let relationship = $(useRelationship(account))
 
 const isSelf = $(useSelfAccount(() => account))
+const notLocal = $computed(() => getServerName(account) !== currentServer.value)
 
 const { t } = useI18n()
 const { client } = $(useMasto())
@@ -59,7 +60,7 @@ async function removeUserNote() {
     </button>
 
     <template #popper>
-      <NuxtLink :to="account.url" external target="_blank">
+      <NuxtLink v-if="notLocal" :to="account.url" external target="_blank">
         <CommonDropdownItem
           :text="$t('menu.open_in_original_site')"
           icon="i-ri:arrow-right-up-line"

--- a/composables/masto/routes.ts
+++ b/composables/masto/routes.ts
@@ -2,10 +2,11 @@ import { withoutProtocol } from 'ufo'
 import type { mastodon } from 'masto'
 
 export function getAccountRoute(account: mastodon.v1.Account) {
+  const singleInstanceServer = useRuntimeConfig().public.singleInstance
   return useRouter().resolve({
     name: 'account-index',
     params: {
-      server: currentServer.value,
+      ...(!singleInstanceServer && { server: currentServer.value }),
       account: extractAccountHandle(account),
     },
   })


### PR DESCRIPTION
[SOCIALPLAT-561](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-561)

Before:
- command-click on Account name or profile pic would lead to a broken link
- on local (Mozilla Social) account pages, clicking the "three dots" would bring up a menu that had "Open in original site" option", which would just lead you back to the same page

After:
- command-click no longer results in broken link
- three dot menu hides the "original site" option when you are viewing a local account (remains unchanged for remote accounts)