### PR TITLE
fix(discover): adding template for recommendation cards [SOC-46]

### DIFF
--- a/components/timeline/TimelineDiscover.vue
+++ b/components/timeline/TimelineDiscover.vue
@@ -30,21 +30,23 @@ function updateUTM(url: string): string {
         :to="updateUTM(item.url)"
         target="_blank"
         external
-        style="padding: 16px 8px"
-        border="b base" flex
+        p-y-16px
+        p-x-8px
+        flex
+        border="b base"
       >
         <div class="content" w-full pr>
           <h4 text-sm text-secondary>
             {{ item.publisher }}
           </h4>
-          <h3 text-lg line-height-tight font-500 style="margin: 4px 0 4px">
+          <h3 text-lg line-height-tight font-500 m-y-4px>
             {{ shorten(item.title, 100) }}
           </h3>
           <p>
             {{ shorten(item.excerpt, 140) }}
           </p>
         </div>
-        <div class="media" relative overflow-hidden style="min-width: 120px; max-width: 120px;">
+        <div class="media" relative overflow-hidden max-w-120px min-w-120px>
           <img :src="item.imageUrl" rounded-lg overflow-hidden w-full ha>
         </div>
       </NuxtLink>

--- a/components/timeline/TimelineDiscover.vue
+++ b/components/timeline/TimelineDiscover.vue
@@ -6,10 +6,54 @@ const { locale: lang } = useI18n()
 const locale = getLanguageForRecs(lang.value)
 
 const recommendations: Recommendation[] = await $fetch(`/api/recommendations?locale=${locale}`)
+
+// Shorten a string to less than maxLen characters without truncating words.
+function shorten(str: string, maxLen: number): string {
+  if (str.length <= maxLen)
+    return str
+  return `${str.slice(0, str.lastIndexOf(' ', maxLen))}...`
+}
+
+// This is temporary untill we are able to fetch from the new endpoint
+function updateUTM(url: string): string {
+  return url.replace('pocket-newtab', 'mozilla')
+}
 </script>
 
 <template>
-  <div>
-    Coming soon...
-  </div>
+  <h1 text-2xl p-2>
+    Today’s Top Picks
+  </h1>
+  <main>
+    <template v-for="item in recommendations" :key="item.tileId">
+      <NuxtLink
+        :to="updateUTM(item.url)"
+        target="_blank"
+        external
+        style="padding: 16px 8px"
+        border="b base" flex
+      >
+        <div class="content" w-full pr>
+          <h4 text-sm text-secondary>
+            {{ item.publisher }}
+          </h4>
+          <h3 text-lg line-height-tight font-500 style="margin: 4px 0 4px">
+            {{ shorten(item.title, 100) }}
+          </h3>
+          <p>
+            {{ shorten(item.excerpt, 140) }}
+          </p>
+        </div>
+        <div class="media" relative overflow-hidden style="min-width: 120px; max-width: 120px;">
+          <img :src="item.imageUrl" rounded-lg overflow-hidden w-full ha>
+        </div>
+      </NuxtLink>
+    </template>
+  </main>
 </template>
+
+<style scoped>
+  a:hover h3 {
+    text-decoration: underline;
+  }
+</style>


### PR DESCRIPTION
## Description

Adding the template so we can display recommendations on Discover

[Jira ticket](https://mozilla-hub.atlassian.net/browse/SOC-46)

## Implementation Details

Took some liberties with the [Figma design](https://www.figma.com/file/QquqdFHNTs8E5ZgW6VImGL/Moz-Social---Design-System-Library-(Working-File)?type=design&node-id=520-6304&mode=design&t=88IIbVNfmcJQh7Tp-0) so it could use the unocss shorthand.

If we need to we can pull the Recommendation specific template into a separate component, but I figured this was a good way to get it on the page so people can start playing with it. 

<img width="1206" alt="image" src="https://github.com/MozillaSocial/elk/assets/1273879/c9a5d57f-3668-4998-b621-822edc39e376">

