### PR TITLE
fix(UI): hide Translate Post button if a translation API endpoint isn't specified

### DIFF
--- a/composables/masto/translate.ts
+++ b/composables/masto/translate.ts
@@ -103,7 +103,7 @@ export function useTranslation(status: mastodon.v1.Status | mastodon.v1.StatusEd
     && supportedTranslationCodes.includes(to as any)
     && supportedTranslationCodes.includes(status.language as any)
     && !userSettings.value.disabledTranslationLanguages.includes(status.language)
-  const enabled = /*! !useRuntimeConfig().public.translateApi && */ shouldTranslate
+  const enabled = !!useRuntimeConfig().public.translateApi && shouldTranslate
 
   async function toggle() {
     if (!shouldTranslate)


### PR DESCRIPTION
I was poking around translation-related things and discovered this [old commit](https://github.com/elk-zone/elk/pull/1371/commits/646248f078a68f857264bfafb41b2f1c97c8f8f5) from upstream that I think introduced a bug with `shouldTranslate` behavior.

Figured I'd open a PR to revert that change and hide the translate button, since we don't know have a roadmap for adding translation yet.