### PR TITLE
fix(fxa): update settings language to remove Firefox [SOC-120]

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -549,8 +549,8 @@
         "label": "Featured hashtags"
       },
       "fxa_settings": {
-        "description": "Change your password and Firefox account preferences",
-        "label": "Firefox account settings"
+        "description": "Change your password and account preferences",
+        "label": "Account settings"
       },
       "label": "Profile",
       "moso_settings": {


### PR DESCRIPTION
## Goal

Update any text and images that reference Firefox Accounts in preparation for the FxA -> MozA rebrand [SOC-120](https://mozilla-hub.atlassian.net/browse/SOC-120)

## To Do:

- [x] Ctrl+F 'firefox'
- [x] Update 
- [x] Make sure there are no images that reference FxA



Before:
<img width="481" alt="image" src="https://github.com/MozillaSocial/elk/assets/14023085/328336af-fa6f-4286-b138-c3e6665cd2f8">


After:
<img width="555" alt="image" src="https://github.com/MozillaSocial/elk/assets/14023085/d822ece3-f8c6-4a90-9f1c-9a73b9406f13">

