### PR TITLE
fix(glean): rename events to use kebab case

### DIFF
--- a/components/account/AccountHeader.vue
+++ b/components/account/AccountHeader.vue
@@ -52,7 +52,7 @@ function previewAvatar() {
 }
 
 async function toggleNotifications() {
-  const dataGlean = relationship?.notifying ? 'profile.notify_stop' : 'profile.notify_start'
+  const dataGlean = relationship?.notifying ? 'profile.notify.stop' : 'profile.notify.start'
   engagement.record({
     ui_identifier: dataGlean,
     mastodon_account_id: account.id,

--- a/components/account/AccountHeader.vue
+++ b/components/account/AccountHeader.vue
@@ -163,7 +163,7 @@ const personalNoteMaxLength = 2000
                     :aria-label="$t('list.modify_account')"
                     rounded-full text-sm p2 border-1 transition-colors
                     border-base hover:text-primary
-                    data-glean="profile.modify_lists"
+                    data-glean="profile.modify-lists"
                   >
                     <span i-ri:play-list-add-fill block text-current />
                   </button>

--- a/components/account/AccountMoreButton.vue
+++ b/components/account/AccountMoreButton.vue
@@ -33,7 +33,7 @@ function recordEngagement(dataGlean) {
 }
 
 function shareAccount() {
-  recordEngagement('profile.more.share_account')
+  recordEngagement('profile.more.share-account')
   share({ url: location.href })
 }
 
@@ -45,10 +45,10 @@ async function toggleReblogs() {
       cancel: t('confirm.show_reblogs.cancel'),
     }) !== 'confirm')
       return
-    recordEngagement('profile.more.show_boosts')
+    recordEngagement('profile.more.show-boosts')
   }
   else {
-    recordEngagement('profile.more.hide_boosts')
+    recordEngagement('profile.more.hide-boosts')
   }
 
   const showingReblogs = !relationship?.showingReblogs
@@ -56,12 +56,12 @@ async function toggleReblogs() {
 }
 
 async function addUserNote() {
-  recordEngagement('profile.more.add_note')
+  recordEngagement('profile.more.add-note')
   emit('addNote')
 }
 
 async function removeUserNote() {
-  recordEngagement('profile.more.remove_note')
+  recordEngagement('profile.more.remove-note')
 
   if (!relationship!.note || relationship!.note.length === 0)
     return
@@ -92,7 +92,7 @@ function report() {
           :text="$t('menu.open_in_original_site')"
           icon="i-ri:arrow-right-up-line"
           :command="command"
-          data-glean="profile.more.open_in_original_site"
+          data-glean="profile.more.open-in-original-site"
         />
       </NuxtLink>
       <CommonDropdownItem
@@ -118,7 +118,7 @@ function report() {
             :text="$t('menu.direct_message_account', [`@${account.acct}`])"
             icon="i-ri:message-3-line"
             :command="command"
-            @click="directMessageUser(account, 'profile.more.direct_message')"
+            @click="directMessageUser(account, 'profile.more.direct-message')"
           />
 
           <CommonDropdownItem
@@ -196,7 +196,7 @@ function report() {
               :text="$t('menu.block_domain', [getServerName(account)])"
               icon="i-ri:shut-down-line"
               :command="command"
-              @click="toggleBlockDomain(relationship!, account, 'profile.more.block_domain')"
+              @click="toggleBlockDomain(relationship!, account, 'profile.more.block-domain')"
             />
             <CommonDropdownItem
               is="button"
@@ -204,7 +204,7 @@ function report() {
               :text="$t('menu.unblock_domain', [getServerName(account)])"
               icon="i-ri:restart-line"
               :command="command"
-              @click="toggleBlockDomain(relationship!, account, 'profile.more.unblock_domain')"
+              @click="toggleBlockDomain(relationship!, account, 'profile.more.unblock-domain')"
             />
           </template>
 
@@ -219,19 +219,19 @@ function report() {
 
         <template v-else>
           <NuxtLink to="/pinned">
-            <CommonDropdownItem is="button" :text="$t('account.pinned')" icon="i-ri:pushpin-line" :command="command" data-glean="profile.more.goto_pinned" />
+            <CommonDropdownItem is="button" :text="$t('account.pinned')" icon="i-ri:pushpin-line" :command="command" data-glean="profile.more.goto-pinned" />
           </NuxtLink>
           <NuxtLink to="/favourites">
-            <CommonDropdownItem is="button" :text="$t('account.favourites')" :icon="useStarFavoriteIcon ? 'i-ri:star-line' : 'i-ri:heart-3-line'" :command="command" data-glean="profile.more.goto_favorites" />
+            <CommonDropdownItem is="button" :text="$t('account.favourites')" :icon="useStarFavoriteIcon ? 'i-ri:star-line' : 'i-ri:heart-3-line'" :command="command" data-glean="profile.more.goto-favorites" />
           </NuxtLink>
           <NuxtLink to="/mutes">
-            <CommonDropdownItem is="button" :text="$t('account.muted_users')" icon="i-ri:volume-mute-line" :command="command" data-glean="profile.more.goto_mutes" />
+            <CommonDropdownItem is="button" :text="$t('account.muted_users')" icon="i-ri:volume-mute-line" :command="command" data-glean="profile.more.goto-mutes" />
           </NuxtLink>
           <NuxtLink to="/blocks">
-            <CommonDropdownItem is="button" :text="$t('account.blocked_users')" icon="i-ri:forbid-2-line" :command="command" data-glean="profile.more.goto_blocks" />
+            <CommonDropdownItem is="button" :text="$t('account.blocked_users')" icon="i-ri:forbid-2-line" :command="command" data-glean="profile.more.goto-blocks" />
           </NuxtLink>
           <NuxtLink to="/domain_blocks">
-            <CommonDropdownItem is="button" :text="$t('account.blocked_domains')" icon="i-ri:shut-down-line" :command="command" data-glean="profile.more.goto_domain_blocks" />
+            <CommonDropdownItem is="button" :text="$t('account.blocked_domains')" icon="i-ri:shut-down-line" :command="command" data-glean="profile.more.goto-domain-blocks" />
           </NuxtLink>
         </template>
       </template>

--- a/components/account/AccountMoreButton.vue
+++ b/components/account/AccountMoreButton.vue
@@ -23,7 +23,7 @@ const { client } = $(useMasto())
 const useStarFavoriteIcon = usePreferences('useStarFavoriteIcon')
 const { share, isSupported: isShareSupported } = useShare()
 
-function recordEngagement(dataGlean) {
+function recordEngagement(dataGlean: string) {
   engagement.record({
     ui_identifier: dataGlean,
     mastodon_account_id: account.id,

--- a/components/settings/SettingsColorMode.vue
+++ b/components/settings/SettingsColorMode.vue
@@ -31,7 +31,7 @@ const modes = [
     <button
       v-for="{ icon, label, mode } in modes"
       :key="mode"
-      data-glean="settings.interface.colorMode"
+      data-glean="settings.interface.color-mode"
       :data-glean-value="`${mode}`"
       btn-text flex-1 flex="~ gap-1 center" p4 border="~ base rounded" bg-base ws-nowrap
       :tabindex="colorMode.preference === mode ? 0 : -1"

--- a/components/settings/SettingsFontSize.vue
+++ b/components/settings/SettingsFontSize.vue
@@ -22,7 +22,7 @@ function setFontSize(e: Event) {
         :min="0"
         :max="sizes.length - 1"
         :step="1"
-        data-glean="settings.interface.fontSize"
+        data-glean="settings.interface.font-size"
         :data-glean-value="`${sizes.indexOf(userSettings.fontSize)}`"
         type="range"
         focus:outline-none

--- a/components/settings/SettingsThemeColors.vue
+++ b/components/settings/SettingsThemeColors.vue
@@ -21,7 +21,7 @@ function updateTheme(theme: ThemeColors) {
       }"
       :class="currentTheme === key ? 'ring-2' : 'scale-90'"
       :title="key"
-      data-glean="settings.interface.themeColor"
+      data-glean="settings.interface.theme-color"
       :data-glean-value="`${key}`"
       w-8 h-8 rounded-full transition-all
       ring="$local-ring-color offset-3 offset-$c-bg-base"

--- a/telemetry/engagementDetails.ts
+++ b/telemetry/engagementDetails.ts
@@ -8,13 +8,13 @@ interface EngagementDetails {
 }
 
 export const engagementDetails: EngagementDetails = {
-  'settings.interface.colorMode': {
+  'settings.interface.color-mode': {
     engagement_type: 'general',
   },
-  'settings.interface.fontSize': {
+  'settings.interface.font-size': {
     engagement_type: 'general',
   },
-  'settings.interface.themeColor': {
+  'settings.interface.theme-color': {
     engagement_type: 'general',
   },
   ...profileEvents,

--- a/telemetry/engagementProfileEvents.js
+++ b/telemetry/engagementProfileEvents.js
@@ -22,28 +22,28 @@ export const profileEvents = {
   'profile.more.open': {
     engagement_type: 'general',
   },
-  'profile.more.open_in_original_site': {
+  'profile.more.open-in-original-site': {
     engagement_type: 'general',
   },
-  'profile.more.share_account': {
+  'profile.more.share-account': {
     engagement_type: 'general',
   },
   'profile.more.mention': {
     engagement_type: 'general',
   },
-  'profile.more.direct_message': {
+  'profile.more.direct-message': {
     engagement_type: 'general',
   },
-  'profile.more.show_boosts': {
+  'profile.more.show-boosts': {
     engagement_type: 'general',
   },
-  'profile.more.hide_boosts': {
+  'profile.more.hide-boosts': {
     engagement_type: 'general',
   },
-  'profile.more.add_note': {
+  'profile.more.add-note': {
     engagement_type: 'general',
   },
-  'profile.more.remove_note': {
+  'profile.more.remove-note': {
     engagement_type: 'general',
   },
   'profile.more.mute': {
@@ -58,28 +58,28 @@ export const profileEvents = {
   'profile.more.unblock': {
     engagement_type: 'general',
   },
-  'profile.more.block_domain': {
+  'profile.more.block-domain': {
     engagement_type: 'general',
   },
-  'profile.more.unblock_domain': {
+  'profile.more.unblock-domain': {
     engagement_type: 'general',
   },
   'profile.more.report': {
     engagement_type: 'general',
   },
-  'profile.more.goto_pinned': {
+  'profile.more.goto-pinned': {
     engagement_type: 'general',
   },
-  'profile.more.goto_favorites': {
+  'profile.more.goto-favorites': {
     engagement_type: 'general',
   },
-  'profile.more.goto_mutes': {
+  'profile.more.goto-mutes': {
     engagement_type: 'general',
   },
-  'profile.more.goto_blocks': {
+  'profile.more.goto-blocks': {
     engagement_type: 'general',
   },
-  'profile.more.goto_domain_blocks': {
+  'profile.more.goto-domain-blocks': {
     engagement_type: 'general',
   },
   // notifications
@@ -90,7 +90,7 @@ export const profileEvents = {
     engagement_type: 'general',
   },
   // modify lists
-  'profile.modify_lists': {
+  'profile.modify-lists': {
     engagement_type: 'general',
   },
   // metrics details (# of posts, # of following, # of followers)
@@ -107,7 +107,7 @@ export const profileEvents = {
   'profile.tabs.posts': {
     engagement_type: 'general',
   },
-  'profile.tabs.posts_and_replies': {
+  'profile.tabs.posts-and-replies': {
     engagement_type: 'general',
   },
   'profile.tabs.media': {

--- a/telemetry/engagementProfileEvents.js
+++ b/telemetry/engagementProfileEvents.js
@@ -83,10 +83,10 @@ export const profileEvents = {
     engagement_type: 'general',
   },
   // notifications
-  'profile.notify_start': {
+  'profile.notify.start': {
     engagement_type: 'general',
   },
-  'profile.notify_stop': {
+  'profile.notify.stop': {
     engagement_type: 'general',
   },
   // modify lists


### PR DESCRIPTION
While reviewing #67 I noticed that we had a mix of cases when it came to naming our engagement events, so I reached out to the data analytics team to see if they had a preference. They [decided](https://mozilla.slack.com/archives/C05EBRU3V1U/p1697749553620799) on `kebab-case`, so this PR simply updates the existing engagement events, plus those in #67, to be consistent. Two other small changes called out in comments.

This PR is to be merged into #67.