### PR TITLE
fix(discover): update engagement type for discover share action

### DIFF
--- a/telemetry/engagementDetails.ts
+++ b/telemetry/engagementDetails.ts
@@ -19,6 +19,6 @@ export const engagementDetails: EngagementDetails = {
     engagement_type: 'general',
   },
   'discover.recommendation.share': {
-    engagement_type: 'general',
+    engagement_type: 'share',
   },
 }


### PR DESCRIPTION
Updating the engagement type for this action to `share` instead of `general`