### PR TITLE
fix(analytics): capture engagement events on children of <a>'s

### DIFF
--- a/modules/glean/runtime/glean-plugin.client.ts
+++ b/modules/glean/runtime/glean-plugin.client.ts
@@ -37,16 +37,20 @@ export default defineNuxtPlugin((nuxtApp) => {
       if (!element)
         return
 
+      if (!element.hasAttribute('data-glean'))
+        return
+
       const data = element.getAttribute('data-glean') || ''
-      if (element.hasAttribute('data-glean')) {
-        const value = element.getAttribute('data-glean-value') || ''
-        engagement.record({ ui_identifier: data, engagement_value: value, ...engagementDetails[data] })
-      }
+      const value = element.getAttribute('data-glean-value') || ''
+      engagement.record({ ui_identifier: data, engagement_value: value, ...engagementDetails[data] })
     }
 
     function handleButtonClick(ev: MouseEvent) {
       const eventTarget = ev?.target as Element
       const closestButton = eventTarget.closest('button')
+
+      if (!closestButton)
+        return
 
       if (closestButton?.hasAttribute('href'))
         linkClick.record({ target_url: closestButton.getAttribute('href') || '' })
@@ -57,10 +61,13 @@ export default defineNuxtPlugin((nuxtApp) => {
     function handleLinkClick(ev: MouseEvent) {
       const eventTarget = ev?.target as Element
       const closestLink = eventTarget.closest('a')
-      if (closestLink) {
-        linkClick.record({ target_url: closestLink.getAttribute('href') || '' })
-        recordEngagement(closestLink)
-      }
+
+      if (!closestLink)
+        return
+
+      linkClick.record({ target_url: closestLink.getAttribute('href') || '' })
+
+      recordEngagement(closestLink)
     }
 
     window.addEventListener('click', eventListener)

--- a/modules/glean/runtime/glean-plugin.client.ts
+++ b/modules/glean/runtime/glean-plugin.client.ts
@@ -33,6 +33,17 @@ export default defineNuxtPlugin((nuxtApp) => {
       }
     }
 
+    function recordEngagement(element: Element) {
+      if (!element)
+        return
+
+      const data = element.getAttribute('data-glean') || ''
+      if (element.hasAttribute('data-glean')) {
+        const value = element.getAttribute('data-glean-value') || ''
+        engagement.record({ ui_identifier: data, engagement_value: value, ...engagementDetails[data] })
+      }
+    }
+
     function handleButtonClick(ev: MouseEvent) {
       const eventTarget = ev?.target as Element
       const closestButton = eventTarget.closest('button')
@@ -40,17 +51,16 @@ export default defineNuxtPlugin((nuxtApp) => {
       if (closestButton?.hasAttribute('href'))
         linkClick.record({ target_url: closestButton.getAttribute('href') || '' })
 
-      const data = eventTarget?.getAttribute('data-glean') || ''
-      const value = eventTarget?.getAttribute('data-glean-value') || ''
-      if (eventTarget.hasAttribute('data-glean'))
-        engagement.record({ ui_identifier: data, engagement_value: value, ...engagementDetails[data] })
+      recordEngagement(eventTarget)
     }
 
     function handleLinkClick(ev: MouseEvent) {
       const eventTarget = ev?.target as Element
       const closestLink = eventTarget.closest('a')
-      if (closestLink)
+      if (closestLink) {
         linkClick.record({ target_url: closestLink.getAttribute('href') || '' })
+        recordEngagement(closestLink)
+      }
     }
 
     window.addEventListener('click', eventListener)


### PR DESCRIPTION
Goal: clicking on any part of a link should trigger engagement events.

Currently, our code is not setup to handle clicks on children of an anchor `<a>` tag.

This PR is a follow up improvement to https://github.com/MozillaSocial/elk/pull/67#discussion_r1368881577

## To Do:

- [x] Copy button code to anchor code
- [x] Break out into re-usable function between button click and link click functions
- [x] Change button click function to only capture buttons

Image showing the bounding box of a nested `<span>` in an `<a>` 
<img src="https://user-images.githubusercontent.com/14023085/277800121-b590ffdf-00d6-4091-8da1-031336008d38.png">