### PR TITLE
fix(posts): track when users click links within posts [MOSOWEB-49]

### DIFF
--- a/components/status/StatusLink.vue
+++ b/components/status/StatusLink.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import type { mastodon } from 'masto'
+import { engagement } from '~~/telemetry/generated/ui'
+import { engagementDetails } from '~~/telemetry/engagementDetails'
 
 const props = defineProps<{
   status: mastodon.v1.Status
@@ -16,6 +18,13 @@ function onclick(evt: MouseEvent | KeyboardEvent) {
   const text = window.getSelection()?.toString()
   if (!el && !text)
     go(evt)
+
+  const eventTarget = evt?.target as Element
+  const closestLink = eventTarget.closest('a')
+  if (closestLink) {
+    const ui_identifier = 'post.link.tap'
+    engagement.record({ ui_identifier, mastodon_status_id: props.status.id, ...engagementDetails[ui_identifier] })
+  }
 }
 
 function go(evt: MouseEvent | KeyboardEvent) {

--- a/telemetry/engagementDetails.ts
+++ b/telemetry/engagementDetails.ts
@@ -1,3 +1,4 @@
+import { postEvents } from './engagementPostEvents'
 import { profileEvents } from './engagementProfileEvents'
 
 interface EngagementDetails {
@@ -35,5 +36,6 @@ export const engagementDetails: EngagementDetails = {
   'nav.login': {
     engagement_type: 'general',
   },
+  ...postEvents,
   ...profileEvents,
 }

--- a/telemetry/engagementPostEvents.js
+++ b/telemetry/engagementPostEvents.js
@@ -1,5 +1,5 @@
 export const postEvents = {
   'post.link.tap': {
-    engagement_type: 'post',
+    engagement_type: 'general',
   },
 }

--- a/telemetry/engagementPostEvents.js
+++ b/telemetry/engagementPostEvents.js
@@ -1,0 +1,5 @@
+export const postEvents = {
+  'post.link.tap': {
+    engagement_type: 'post',
+  },
+}


### PR DESCRIPTION
Goal: When a user clicks a link within a post, we need to log an engagement event. [MOSOWEB-49
](https://mozilla-hub.atlassian.net/browse/MOSOWEB-49)

## To Do:

- [x] Hook into the click handler for the whole Post
- [x] Fire engagement event
- [x] Send post ID

Example of a post with a link
<img width="621" alt="image" src="https://github.com/MozillaSocial/elk/assets/14023085/b1081366-702a-45a0-8263-3dd68f69ee2e">

Engagement event showing up in Debug Ping Viewer
<img width="1422" alt="image" src="https://github.com/MozillaSocial/elk/assets/14023085/647c2200-03bc-4d93-ab0b-bf4de7e9ea23">

