### PR TITLE
fix(post): post creation interactions [MOSOWEB-46]

### DIFF
--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -2,6 +2,8 @@
 import { EditorContent } from '@tiptap/vue-3'
 import stringLength from 'string-length'
 import type { mastodon } from 'masto'
+import { engagement } from '~~/telemetry/generated/ui'
+import { engagementDetails } from '~~/telemetry/engagementDetails'
 import type { Draft } from '~/types'
 
 const {
@@ -10,6 +12,7 @@ const {
   expanded = false,
   placeholder,
   dialogLabelledBy,
+  feedName,
 } = defineProps<{
   draftKey?: string
   initial?: () => Draft
@@ -18,6 +21,7 @@ const {
   inReplyToVisibility?: mastodon.v1.StatusVisibility
   expanded?: boolean
   dialogLabelledBy?: string
+  feedName?: string
 }>()
 
 const emit = defineEmits<{
@@ -171,8 +175,15 @@ async function toggleSensitive() {
 
 async function publish() {
   const status = await publishDraft()
-  if (status)
+  if (status) {
+    const analyticsId = feedName ? `${feedName}.post.create` : 'post.create'
+    engagement.record({
+      ui_identifier: analyticsId,
+      mastodon_status_id: status.id,
+      ...engagementDetails[analyticsId],
+    })
     emit('published', status)
+  }
 }
 
 useWebShareTarget(async ({ data: { data, action } }: any) => {

--- a/components/publish/PublishWidget.vue
+++ b/components/publish/PublishWidget.vue
@@ -174,9 +174,14 @@ async function toggleSensitive() {
 }
 
 async function publish() {
+  const isEditing = draft.editingStatus // need to save this before publishDraft
   const status = await publishDraft()
   if (status) {
-    const analyticsId = feedName ? `${feedName}.post.create` : 'post.create'
+    const analyticsId = isEditing
+      ? 'post.edit'
+      : draft.params.inReplyToId
+        ? 'post.reply'
+        : feedName ? `${feedName}.post.create` : 'post.create'
     engagement.record({
       ui_identifier: analyticsId,
       mastodon_status_id: status.id,

--- a/components/publish/PublishWidgetFull.client.vue
+++ b/components/publish/PublishWidgetFull.client.vue
@@ -64,7 +64,7 @@ onDeactivated(() => {
       </VDropdown>
     </div>
     <div>
-      <PublishWidget :key="draftKey" expanded class="min-h-100!" :draft-key="draftKey" @published="onPublish" />
+      <PublishWidget :key="draftKey" expanded class="min-h-100!" :draft-key="draftKey" feed-name="" @published="onPublish" />
     </div>
   </div>
 </template>

--- a/components/timeline/TimelineHome.vue
+++ b/components/timeline/TimelineHome.vue
@@ -17,7 +17,7 @@ function onPublish(status) {
 
 <template>
   <div>
-    <PublishWidget draft-key="home" border="b base" @published="onPublish" />
+    <PublishWidget draft-key="home" border="b base" feed-name="home" @published="onPublish" />
     <TimelinePaginator ref="homePaginator" v-bind="{ paginator, stream }" :preprocess="reorderAndFilter" context="home" />
   </div>
 </template>

--- a/telemetry/engagementDetails.ts
+++ b/telemetry/engagementDetails.ts
@@ -35,5 +35,17 @@ export const engagementDetails: EngagementDetails = {
   'nav.login': {
     engagement_type: 'general',
   },
+  'home.post.create': {
+    engagement_type: 'post',
+  },
+  'post.create': {
+    engagement_type: 'post',
+  },
+  'post.edit': {
+    engagement_type: 'post',
+  },
+  'post.reply': {
+    engagement_type: 'post',
+  },
   ...profileEvents,
 }


### PR DESCRIPTION
MOSOWEB-46 https://mozilla-hub.atlassian.net/browse/MOSOWEB-46

## Goal
All post creations, replies and edits should have an analytics action associated.

Send the following Engagement Event:
```
engagement event
ui_identifier is post.create (or something like that)
Includes a mastodon_status_id that we can cross-reference against prod data
engagement_type is post
```

## I'd love feedback/perspectives on:
- Do I buy [Lego 10305 - Lion Knights' Castle](https://www.lego.com/en-us/product/lion-knights-castle-10305)? Non-Star Wars building sets are suddenly really enticing to me.
 
## Implementation Decisions
- The oddball in the list of new events, `home.post.create`, is a decision from Kirill

## New analytics events

- home.post.create
- post.create
- post.edit
- post.reply
  