### PR TITLE
fix(settings): change elk to moz social in notifications settings [MOSOWEB-89]

### DIFF
--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -479,10 +479,10 @@
         "unsupported": "Ihr Browser unterstützt keine Push-Benachrichtigungen.",
         "warning": {
           "enable_close": "Schließen",
-          "enable_description": "Um Benachrichtigungen zu erhalten, wenn Elk nicht geöffnet ist, aktiviere Push-Benachrichtigungen. \nDu kannst genau steuern, welche Arten von Interaktionen Push-Benachrichtigungen generieren, indem du die Schaltfläche \"@:settings.notifications.show_btn{'\"'} oben aktivierest, sobald sie aktiviert ist.",
-          "enable_description_desktop": "Um Benachrichtigungen zu erhalten, wenn Elk nicht geöffnet ist, aktiviere Push-Benachrichtigungen. \nDu kannst unter „Einstellungen > Benachrichtigungen > Einstellungen für Push-Benachrichtigungen“ genau steuern, welche Arten von Interaktionen Push-Benachrichtigungen generieren, sobald diese aktiviert sind.",
+          "enable_description": "Um Benachrichtigungen zu erhalten, wenn Mozilla.social nicht geöffnet ist, aktiviere Push-Benachrichtigungen. \nDu kannst genau steuern, welche Arten von Interaktionen Push-Benachrichtigungen generieren, indem du die Schaltfläche \"@:settings.notifications.show_btn{'\"'} oben aktivierest, sobald sie aktiviert ist.",
+          "enable_description_desktop": "Um Benachrichtigungen zu erhalten, wenn Mozilla.social nicht geöffnet ist, aktiviere Push-Benachrichtigungen. \nDu kannst unter „Einstellungen > Benachrichtigungen > Einstellungen für Push-Benachrichtigungen“ genau steuern, welche Arten von Interaktionen Push-Benachrichtigungen generieren, sobald diese aktiviert sind.",
           "enable_description_mobile": "Du erreichst die Einstellungen auch über das Navigationsmenü „Einstellungen > Benachrichtigungen > Push-Benachrichtigungseinstellungen“.",
-          "enable_description_settings": "Um Benachrichtigungen zu erhalten, wenn Elk nicht geöffnet ist, aktiviere Push-Benachrichtigungen. \nDu kannst genau steuern, welche Arten von Interaktionen Push-Benachrichtigungen auf demselben Bildschirm generieren, sobald du sie aktivierst.",
+          "enable_description_settings": "Um Benachrichtigungen zu erhalten, wenn Mozilla.social nicht geöffnet ist, aktiviere Push-Benachrichtigungen. \nDu kannst genau steuern, welche Arten von Interaktionen Push-Benachrichtigungen auf demselben Bildschirm generieren, sobald du sie aktivierst.",
           "enable_desktop": "Aktiviere Push-Benachrichtigungen",
           "enable_title": "Verpasse nie wieder Benachrichtigungen",
           "re_auth": "Offenbar unterstützt dein Server keine Push-Benachrichtigungen. \nVersuche dich abzumelden und erneut anzumelden. Wenn diese Meldung weiterhin angezeigt wird, wende dich an dein Serveradministrator."

--- a/locales/en.json
+++ b/locales/en.json
@@ -524,10 +524,10 @@
         "unsupported": "Your browser does not support push notifications.",
         "warning": {
           "enable_close": "Close",
-          "enable_description": "To receive notifications when Elk is not open, enable push notifications. You can control precisely what types of interactions generate push notifications via the \"@:settings.notifications.show_btn{'\"'} button above once enabled.",
-          "enable_description_desktop": "To receive notifications when Elk is not open, enable push notifications. You can control precisely what types of interactions generate push notifications in \"Settings > Notifications > Push notifications settings\" once enabled.",
+          "enable_description": "To receive notifications when Mozilla.social is not open, enable push notifications. You can control precisely what types of interactions generate push notifications via the \"@:settings.notifications.show_btn{'\"'} button above once enabled.",
+          "enable_description_desktop": "To receive notifications when Mozilla.social is not open, enable push notifications. You can control precisely what types of interactions generate push notifications in \"Settings > Notifications > Push notifications settings\" once enabled.",
           "enable_description_mobile": "You can also access the settings using the navigation menu \"Settings > Notifications > Push notification settings\".",
-          "enable_description_settings": "To receive notifications when Elk is not open, enable push notifications. You will be able to control precisely what types of interactions generate push notifications on this same screen once you enable them.",
+          "enable_description_settings": "To receive notifications when Mozilla.social is not open, enable push notifications. You will be able to control precisely what types of interactions generate push notifications on this same screen once you enable them.",
           "enable_desktop": "Enable push notifications",
           "enable_title": "Never miss anything",
           "re_auth": "It seems that your server does not support push notifications. Try sign out and sign in again, if this message still appears contact your server administrator."


### PR DESCRIPTION
## Goal
Replace "Elk" text from Push Notifications settings with "Mozilla.social" [MOSOWEB-89](https://mozilla-hub.atlassian.net/browse/MOSOWEB-89)


Image of the affected spot in local:
<img width="946" alt="image" src="https://github.com/MozillaSocial/elk/assets/14023085/c05b000a-4d0c-463a-96c0-b03a5c52f974">


## How to Test this

I did some stuff in `components/notification/NotificationPreferences.client.vue` and `pages/settings/notifications/push-notifications.vue` to force my way into the route :shrug:

Something about `pwaEnabled` disallows this page in local