### PR TITLE
fix(rename): replace Elk with Mozilla.social - MOSOWEB-98

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -7,7 +7,7 @@ const route = useRoute()
 if (process.server && !route.path.startsWith('/settings')) {
   useHead({
     meta: [
-      { property: 'og:url', content: `https://elk.zone${route.path}` },
+      { property: 'og:url', content: `https://mozilla.social${route.path}` },
     ],
   })
 }

--- a/components/common/CommonPaginator.vue
+++ b/components/common/CommonPaginator.vue
@@ -52,7 +52,7 @@ function percolateStatus(status) {
   addStatus(status)
 }
 
-nuxtApp.hook('elk-logo:click', () => {
+nuxtApp.hook('moz-logo:click', () => {
   update()
   nuxtApp.$scrollToTop()
 })

--- a/components/nav/NavTitle.vue
+++ b/components/nav/NavTitle.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-const { env } = useBuildInfo()
 const router = useRouter()
 const back = ref<any>('')
 

--- a/components/nav/NavTitle.vue
+++ b/components/nav/NavTitle.vue
@@ -6,7 +6,7 @@ const back = ref<any>('')
 const nuxtApp = useNuxtApp()
 
 function onClickLogo() {
-  nuxtApp.hooks.callHook('elk-logo:click')
+  nuxtApp.hooks.callHook('moz-logo:click')
 }
 
 onMounted(() => {

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -77,7 +77,7 @@
   },
   "app_desc_short": "Ein flinker Mastodon Web-Client",
   "app_logo": "Elk Logo",
-  "app_name": "Elk",
+  "app_name": "Mozilla.social",
   "attachment": {
     "edit_title": "Beschreibung",
     "remove_label": "Anhang entfernen"

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -76,7 +76,7 @@
     "vote": "Abstimmen"
   },
   "app_desc_short": "Ein flinker Mastodon Web-Client",
-  "app_logo": "Elk Logo",
+  "app_logo": "Mozilla Logo",
   "app_name": "Mozilla.social",
   "attachment": {
     "edit_title": "Beschreibung",

--- a/locales/en.json
+++ b/locales/en.json
@@ -92,7 +92,7 @@
   },
   "app_desc_short": "Decentralized social media powered by Mastodon",
   "app_logo": "Mozilla Logo",
-  "app_name": "Mozilla Social",
+  "app_name": "Mozilla.social",
   "attachment": {
     "add_image_description": "Add image description",
     "alt-point-1": "Capture important elements",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -287,7 +287,7 @@ declare global {
 
 declare module '#app' {
   interface RuntimeNuxtHooks {
-    'elk-logo:click': () => void
+    'moz-logo:click': () => void
   }
 }
 


### PR DESCRIPTION
## Goal
Anywhere it's visible to the user, replace `elk` with `Mozilla.social`. [MOSOWEB-98](https://mozilla-hub.atlassian.net/browse/MOSOWEB-98)

## Implementation Details
* Per Laurie, I only focused on the English & German translations
* There are 1154 references to `elk` in the repo. Most of these are in documentation, config, constants, translations (that aren't supported) and dead components. I was pretty thorough in my chasing down of anything that might be visible to the user, and I think I've covered everything