### PR TITLE
fix(config): change application name and website [MOSOWEB-90]

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,4 +1,5 @@
-export const APP_NAME = 'Elk'
+export const APP_NAME = 'Mozilla.social'
+export const APP_WEBSITE = 'https://mozilla.social'
 
 export const DEFAULT_POST_CHARS_LIMIT = 500
 export const DEFAULT_FONT_SIZE = '15px'

--- a/server/utils/shared.ts
+++ b/server/utils/shared.ts
@@ -13,7 +13,7 @@ import { env } from '#build-info'
 import { driver } from '#storage-config'
 
 import type { AppInfo } from '~/types'
-import { APP_NAME } from '~/constants'
+import { APP_NAME, APP_WEBSITE } from '~/constants'
 
 import { makeAbsolutePath } from '~/utils/path.ts'
 
@@ -45,7 +45,7 @@ async function fetchAppInfo(origin: string, server: string) {
     method: 'POST',
     body: {
       client_name: APP_NAME + (env !== 'release' ? ` (${env})` : ''),
-      website: 'https://elk.zone',
+      website: APP_WEBSITE,
       redirect_uris: getRedirectURI(origin, server),
       scopes: 'read write follow push',
     },


### PR DESCRIPTION
[MOSOWEB-90](https://mozilla-hub.atlassian.net/browse/MOSOWEB-90)

### Goal
Bug: When you post on mozilla.social, your post gets a label that says “Elk” and links to “elk.zone”.

### Context
Posts have an `application` field with `name` and `website` data. `application` refers to an instance of [Application](https://docs.joinmastodon.org/entities/Application/)
```
status.application.name: "Elk"
status.application.website: "https://elk.zone/"
```

### Fix
Change the application `name` and `website` fields. This PR is a frontend fix to a fetch call. Backend will do a fix to actually update `name` and `website`