### PR TITLE
chore(glean): finalize adding elk to the Glean pipeline

### DIFF
--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -1,0 +1,6 @@
+---
+name: Glean probe-scraper
+on: [push, pull_request]
+jobs:
+  glean-probe-scraper:
+    uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main


### PR DESCRIPTION
This implements the last step described in [the Glean Book](https://mozilla.github.io/glean/book/user/adding-glean-to-your-project/enable-data-ingestion.html#validate-and-publish-metrics).

Note that the application is [already added](https://dictionary.telemetry.mozilla.org/apps/moso_mastodon_web), but will only show the default metrics until this PR is merged.