### PR TITLE
feat(glean): enable glean in prod - SOCWEB-145

### DIFF
--- a/modules/glean/runtime/glean-plugin.client.ts
+++ b/modules/glean/runtime/glean-plugin.client.ts
@@ -1,10 +1,10 @@
 import Glean from '@mozilla/glean/web'
 import * as log from 'tauri-plugin-log-api'
 
-import { linkClick, pageUrl, pageView, referrerUrl } from '../../../telemetry/generated/web'
-import { userAgent } from '../../../telemetry/generated/identifiers'
-import { engagement } from '../../../telemetry/generated/ui'
-import { engagementDetails } from '../../../telemetry/engagementDetails'
+import { userAgent } from '~~/telemetry/generated/identifiers'
+import { engagement } from '~~/telemetry/generated/ui'
+import { engagementDetails } from '~~/telemetry/engagementDetails'
+import { linkClick, pageUrl, pageView, referrerUrl } from '~~/telemetry/generated/web'
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.hook('app:mounted', () => {
@@ -13,9 +13,11 @@ export default defineNuxtPlugin((nuxtApp) => {
     const GLEAN_APP_ID = 'moso-mastodon-web'
     const env = useAppConfig().env
     const devMode = env === ('dev' || 'canary' || 'preview')
+    const prodMode = env === 'release'
+    const gleanEnabled = (devMode || prodMode)
     const userSettings = useUserSettings()
-    const allowGlean = getPreferences(userSettings.value, 'allowGlean')
-    const uploadEnabled = devMode && allowGlean
+    const userAllowGlean = getPreferences(userSettings.value, 'allowGlean')
+    const uploadEnabled = gleanEnabled && userAllowGlean
 
     Glean.initialize(GLEAN_APP_ID, uploadEnabled, { channel: env })
     userAgent.set(navigator.userAgent)

--- a/modules/glean/runtime/glean-plugin.client.ts
+++ b/modules/glean/runtime/glean-plugin.client.ts
@@ -11,13 +11,11 @@ export default defineNuxtPlugin((nuxtApp) => {
     log.info('Glean: App mounted, start initing glean')
 
     const GLEAN_APP_ID = 'moso-mastodon-web'
-    const env = useAppConfig().env
-    const devMode = env === ('dev' || 'canary' || 'preview')
-    const prodMode = env === 'release'
-    const gleanEnabled = (devMode || prodMode)
+    const env = useBuildInfo().env
+    const devMode = env === 'dev'
     const userSettings = useUserSettings()
     const userAllowGlean = getPreferences(userSettings.value, 'allowGlean')
-    const uploadEnabled = gleanEnabled && userAllowGlean
+    const uploadEnabled = userAllowGlean
 
     Glean.initialize(GLEAN_APP_ID, uploadEnabled, { channel: env })
     userAgent.set(navigator.userAgent)

--- a/modules/glean/runtime/glean-plugin.client.ts
+++ b/modules/glean/runtime/glean-plugin.client.ts
@@ -3,8 +3,8 @@ import * as log from 'tauri-plugin-log-api'
 
 import { userAgent } from '~~/telemetry/generated/identifiers'
 import { engagement } from '~~/telemetry/generated/ui'
-import { engagementDetails } from '~~/telemetry/engagementDetails'
 import { linkClick, pageUrl, pageView, referrerUrl } from '~~/telemetry/generated/web'
+import { engagementDetails } from '~~/telemetry/engagementDetails'
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.hook('app:mounted', () => {

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -12,7 +12,6 @@ useHydratedHead({
 const route = useRoute()
 
 const isRootPath = computedEager(() => route.name === 'settings')
-const devMode = useAppConfig().env === ('dev' || 'canary' || 'preview')
 </script>
 
 <template>
@@ -65,7 +64,6 @@ const devMode = useAppConfig().env === ('dev' || 'canary' || 'preview')
               :match="$route.path.startsWith('/settings/preferences/')"
             />
             <SettingsItem
-              v-if="devMode"
               command
               icon="i-ri-lock-line"
               :text="isHydrated ? $t('settings.privacy.label') : ''"


### PR DESCRIPTION
### Goal

Enable Glean in production so we can start tracking analytics
[SOCWEB-145](https://mozilla-hub.atlassian.net/browse/SOCWEB-145)

### Implementation Details

- [x] ~Added a new variable `const gleanEnabled = (devMode || prodMode)`~
- [x] ~Use new `gleanEnabled` variable when initializing Glean~
- [x] Updated `env` to use `useBuildInfo` rather than `useAppConfig` (not super confident that either of these work the way I think they do)
- [x] Removed the environment check when setting `uploadEnabled`
- [x] Removed the environment check for the privacy page & link
- [x] BONUS: Rename `allowGlean` to `userAllowGlean` to be a little more specific
- [x] BONUS: Adjust imports to be consistent and get rid of the `../../../`

### Question

Right now, this enables Glean for _all_ environments (dev, staging and production). @kirill-demtchouk you should be able to filter the events based on environment via the `channel` that we send through, but I am open to adjusting this so it's not uploading events for all environments. Let me know your thoughts!