### PR TITLE
fix(glean): prefix app channel

### DIFF
--- a/modules/glean/runtime/glean-plugin.client.ts
+++ b/modules/glean/runtime/glean-plugin.client.ts
@@ -17,7 +17,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     const userAllowGlean = getPreferences(userSettings.value, 'allowGlean')
     const uploadEnabled = userAllowGlean
 
-    Glean.initialize(GLEAN_APP_ID, uploadEnabled, { channel: env })
+    Glean.initialize(GLEAN_APP_ID, uploadEnabled, { channel: `elk-${env}` })
     userAgent.set(navigator.userAgent)
 
     // Debugging


### PR DESCRIPTION
Per Kirill's request, we are adding a prefix to the `app_channel` that we send to glean so the data team will be able to differentiate between elk & aquatic.