### PR TITLE
fix(preview card): blurhash on sensitive content 

### DIFF
--- a/components/status/StatusContent.vue
+++ b/components/status/StatusContent.vue
@@ -57,6 +57,7 @@ const hideAllMedia = computed(
       />
       <StatusPreviewCard
         v-if="status.card"
+        :sensitive="status.sensitive"
         :card="status.card"
         :small-picture-only="status.mediaAttachments?.length > 0"
       />

--- a/components/status/StatusPreviewCardNormal.vue
+++ b/components/status/StatusPreviewCardNormal.vue
@@ -5,6 +5,8 @@ const props = defineProps<{
   card: mastodon.v1.PreviewCard
   /** For the preview image, only the small image mode is displayed */
   smallPictureOnly?: boolean
+  /** To use blurhash on preview cards containing sensitive content */
+  sensitive?: boolean
   /** When it is root card in the list, not appear as a child card */
   root?: boolean
 }>()
@@ -30,7 +32,8 @@ const cardTypeIconMap: Record<mastodon.v1.PreviewCardType, string> = {
 }
 
 const userSettings = useUserSettings()
-const shouldLoadAttachment = ref(!getPreferences(userSettings.value, 'enableDataSaving'))
+const noDataSaving = !getPreferences(userSettings.value, 'enableDataSaving')
+const shouldLoadAttachment = ref(noDataSaving && !props.sensitive)
 
 function loadAttachment() {
   shouldLoadAttachment.value = true


### PR DESCRIPTION
This just uses blurhash on images in preview cards that are found in posts marked as sensitive.

## Note
We still don't blurhash images in posts that contain content warnings. So if we show more content on a post there is no clear way of knowing if it contains sensitive images...