### PR TITLE
feat(report): allow anonymous reporting [SOCWEB-197]

### DIFF
--- a/components/status/StatusActionsMore.vue
+++ b/components/status/StatusActionsMore.vue
@@ -322,15 +322,14 @@ function report() {
                 @click="toggleBlockDomain(useRelationship(status.account).value!, status.account)"
               />
             </template>
-
-            <CommonDropdownItem
-              :text="$t('menu.report_account', [`@${status.account.acct}`])"
-              icon="i-ri:flag-2-line"
-              :command="command"
-              @click="report"
-            />
           </template>
         </template>
+        <CommonDropdownItem
+          :text="$t('menu.report_account', [`@${status.account.acct}`])"
+          icon="i-ri:flag-2-line"
+          :command="command"
+          @click="report"
+        />
       </div>
     </template>
   </CommonDropdown>

--- a/locales/en.json
+++ b/locales/en.json
@@ -415,6 +415,7 @@
     "further_actions": {
       "limit": {
         "description": "Here are your options for controlling what you see:",
+        "signup": "You will need to create an account in order to block or mute users.",
         "title": "Don't want to see this?"
       },
       "report": {


### PR DESCRIPTION
## Acceptance Criteria

- Anonymous users will see the option to report user or post
- When an anonymous user submits a post, it’ll go to a different endpoint

## Questions
- Does user needs to add their email for follow-up? 

## Background

We need to add an option to report a potential post/user violation anonymously aka violations reporting for logged out users. 

This is ESSENTIAL for us to meet EU’s DSA deadline of Feb 17. 